### PR TITLE
refactor: Pagination에 대한 interface 분리

### DIFF
--- a/types/apis/base.ts
+++ b/types/apis/base.ts
@@ -3,3 +3,13 @@ export interface BaseResponse {
   status?: number;
   code?: string;
 }
+
+export interface PaginationResponse<T> {
+  content: T[];
+  numberOfElements: number; //content의 요소가 몇개인지
+  offset: number; // 현재 페이지에서 시작하는 요소의 index 번호
+  pageNumber: number; //페이지 넘버
+  pageSize: number; //페이지 사이즈
+  totalElements: number; // 전체 요소 수
+  totalPages: number;
+}

--- a/types/apis/comment/index.ts
+++ b/types/apis/comment/index.ts
@@ -1,18 +1,9 @@
-import { CommentProps } from 'antd';
-import { UserProps } from 'types/model';
-import { BaseResponse } from '../base';
+import { CommentProps } from 'types/model';
+import { BaseResponse, PaginationResponse } from '../base';
 
 //댓글 조회
 export interface CommentReadResponse extends BaseResponse {
-  data?: {
-    content: CommentProps[];
-    numberOfElements: number;
-    offset: number;
-    pageNumber: number;
-    pageSize: number;
-    totalElements: number;
-    totalPages: number;
-  };
+  data?: PaginationResponse<CommentProps>;
 }
 
 //댓글 삭제
@@ -26,27 +17,11 @@ export interface CommentDeleteExhibitionResponse extends BaseResponse {
 
 //댓글 수정
 export interface CommentEditExhibitionResponse extends BaseResponse {
-  data?: {
-    commentId: number;
-    content: string;
-    createdAt: string;
-    updatedAt: string;
-    isEdited: boolean;
-    isDeleted: boolean;
-    user: UserProps;
-  };
+  data?: CommentProps;
 }
 
 //댓글 생성
 
 export interface CommentCreateExhibitionProps extends BaseResponse {
-  data?: {
-    commentId: number;
-    content: string;
-    createdAt: string;
-    updatedAt: string;
-    isEdited: boolean;
-    isDeleted: boolean;
-    user: UserProps[];
-  };
+  data?: CommentProps;
 }

--- a/types/apis/exhibition/index.ts
+++ b/types/apis/exhibition/index.ts
@@ -1,17 +1,11 @@
 import { ExhibitionProps, ReviewProps } from 'types/model';
-import { BaseResponse } from '../base';
+import { BaseResponse, PaginationResponse } from '../base';
 
 //다가오는 전시회, 인기 많은 전시회 조회
+
+// ExhibitionProps
 export interface ExhibitionReadResponse extends BaseResponse {
-  data?: {
-    content: ExhibitionProps[];
-    numberOfElements: number; //content의 요소가 몇개인지
-    offset: number; // 현재 페이지에서 시작하는 요소의 index 번호
-    pageNumber: number; //페이지 넘버
-    pageSize: number; //페이지 사이즈
-    totalElements: number; // 전체 요소 수
-    totalPages: number;
-  };
+  data?: PaginationResponse<ExhibitionProps>;
 }
 
 //전시회 좋아요 토글
@@ -49,13 +43,5 @@ export interface ExhibitionDetailResponse extends BaseResponse {
 
 // 전시회검색
 export interface ExhibitionSearchResponse extends BaseResponse {
-  data?: {
-    content: ReviewProps[];
-    numberOfElements: number; //content의 요소가 몇개인지
-    offset: number; // 현재 페이지에서 시작하는 요소의 index 번호
-    pageNumber: number; //페이지 넘버
-    pageSize: number; //페이지 사이즈
-    totalElements: number; // 전체 요소 수
-    totalPages: number;
-  };
+  data?: PaginationResponse<ReviewProps>;
 }

--- a/types/model.ts
+++ b/types/model.ts
@@ -46,7 +46,7 @@ export interface CommentProps {
   isEdited: boolean;
   isDeleted: boolean;
   user: UserProps;
-  childrenCount: number;
+  childrenCount?: number;
 }
 
 export interface UserProps {


### PR DESCRIPTION
# 작업 내용 (TODO)

- [x] Pagination에 대한 interface 분리

# 사진 (구현 캡쳐)
![image](https://user-images.githubusercontent.com/74234333/182915820-7ea8e005-3c53-40ea-b5f7-2022e08d63b7.png)

Pagination을 활용하는 api 응답 부분이 반복되고 있다는 혜삐의 의견을 통하여 관련 interface를 분리하였습니다.
사용하는 쪽은 다음과 같이 사용합니다.
![image](https://user-images.githubusercontent.com/74234333/182915930-6fec697c-e2a0-4a67-94fc-6da716a2d8b9.png)


# 논의하고 싶은 부분

close #106 
