### PR TITLE
feat: axios 초기 설정 및 API 추가

### DIFF
--- a/apis/comment/index.ts
+++ b/apis/comment/index.ts
@@ -1,0 +1,16 @@
+import { authRequest } from 'apis/common';
+import { CommentCreateRequest, CommentUpdateRequest } from 'types/apis/comment';
+
+const commentAPI = {
+  create: (reviewId: number, payload: CommentCreateRequest) => {
+    return authRequest.post(`/api/v1/reviews/${reviewId}/comments`, payload);
+  },
+  update: (commentId: number, payload: CommentUpdateRequest) => {
+    authRequest.patch(`/api/v1/comments/${commentId}`, payload);
+  },
+  delete: (commentId: number) => {
+    authRequest.delete(`/api/v1/comments/${commentId}`);
+  },
+};
+
+export default commentAPI;

--- a/apis/common.ts
+++ b/apis/common.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+import { storage } from 'utils';
+
+const baseURL = `${process.env.NEXT_PUBLIC_API_END_POINT}`;
+
+const authRequest = axios.create({
+  baseURL,
+});
+
+const unAuthRequest = axios.create({
+  baseURL,
+});
+
+authRequest.interceptors.request.use((config) => {
+  if (config.headers) {
+    config.headers.authorization = 'Bearer ' + storage.getItem('TOKEN', '');
+    return config;
+  }
+});
+
+export { authRequest, unAuthRequest };

--- a/apis/exhibition/index.ts
+++ b/apis/exhibition/index.ts
@@ -1,0 +1,22 @@
+import { unAuthRequest } from 'apis/common';
+
+const exhibitionAPI = {
+  getUpcoming: (page: number, size: number) => {
+    return unAuthRequest.get(`/api/v1/exhibitions/upcoming?page=${page}&size=${size}`);
+  },
+  getMostLike: (page: number, size: number, includeEnd: boolean) => {
+    return unAuthRequest.get(
+      `/api/v1/exhibitions/mostlike?page=${page}&size=${size}&include-end=${includeEnd}`,
+    );
+  },
+  getDetail: (exhibitionId: number) => {
+    return unAuthRequest.get(`/api/v1/exhibitions/${exhibitionId}`);
+  },
+  search: (query: string, page: number, size: number, includeEnd: boolean) => {
+    return unAuthRequest.get(
+      `/api/v1/exhibitions?query=${query}&page=${page}&size=${size}&include-end=${includeEnd}`,
+    );
+  },
+};
+
+export default exhibitionAPI;

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -1,0 +1,4 @@
+export { default as userAPI } from './user';
+export { default as exhibitionAPI } from './exhibition';
+export { default as reviewAPI } from './review';
+export { default as commentAPI } from './comment';

--- a/apis/review/index.ts
+++ b/apis/review/index.ts
@@ -1,0 +1,15 @@
+import { authRequest, unAuthRequest } from 'apis/common';
+
+const reviewAPI = {
+  likeToggle: (reviewId: number) => {
+    return authRequest.patch(`/api/v1/reviews/${reviewId}/like`);
+  },
+  getComments: (reviewId: number, page: number, size: number) => {
+    return unAuthRequest.get(`/api/v1/reviews/${reviewId}/comments?page=${page}&size=${size}`);
+  },
+  searchExhibition: (query: string) => {
+    return unAuthRequest.get(`/api/v1/reviews/search/exhibitions?query=${query}`);
+  },
+};
+
+export default reviewAPI;

--- a/apis/user/index.ts
+++ b/apis/user/index.ts
@@ -1,0 +1,19 @@
+import { unAuthRequest } from 'apis/common';
+import { UserLocalLoginRequest, UserSignupRequest } from 'types/apis/user';
+
+const userAPI = {
+  localLogin: (payload: UserLocalLoginRequest) => {
+    return unAuthRequest.post('/api/v1/users/local/login', payload);
+  },
+  oauthLogin: (code: string) => {
+    return unAuthRequest.post(`api/v1/users/oauth/login?code=${code}`);
+  },
+  signUp: (payload: UserSignupRequest) => {
+    return unAuthRequest.post('api/v1/users/register', payload);
+  },
+  logout: () => {
+    return unAuthRequest.patch('/api/v1/users/logout');
+  },
+};
+
+export default userAPI;

--- a/hooks/useAxios/index.ts
+++ b/hooks/useAxios/index.ts
@@ -1,0 +1,14 @@
+import { useEffect, DependencyList } from 'react';
+import useAxiosFn, { AxiosFunction } from './useAxiosFn';
+
+const useAxios = (axiosFn: AxiosFunction, deps: DependencyList) => {
+  const [state, callback] = useAxiosFn(axiosFn, deps);
+
+  useEffect(() => {
+    callback();
+  }, [callback]);
+
+  return state;
+};
+
+export default useAxios;

--- a/hooks/useAxios/useAxiosFn.ts
+++ b/hooks/useAxios/useAxiosFn.ts
@@ -1,0 +1,43 @@
+import { AxiosError, AxiosResponse } from 'axios';
+import { DependencyList, useCallback, useRef, useState } from 'react';
+
+export type AxiosState = {
+  response?: AxiosResponse;
+  isLoading: boolean;
+  error?: AxiosError;
+};
+
+export type AxiosFunction = () => Promise<AxiosResponse>;
+
+const useAxiosFn = (axiosFn: AxiosFunction, deps: DependencyList): [AxiosState, AxiosFunction] => {
+  const lastCallId = useRef(0);
+  const [state, setState] = useState<AxiosState>({
+    isLoading: false,
+  });
+
+  const callback = useCallback(async () => {
+    const callId = ++lastCallId.current;
+
+    if (!state.isLoading) {
+      setState({ ...state, isLoading: true });
+    }
+
+    return axiosFn()
+      .then((response) => {
+        if (callId === lastCallId.current) {
+          setState({ response, isLoading: false });
+          return response;
+        }
+      })
+      .catch((error) => {
+        if (callId === lastCallId.current) {
+          setState({ error, isLoading: false });
+          return error;
+        }
+      });
+  }, deps);
+
+  return [state, callback];
+};
+
+export default useAxiosFn;

--- a/types/apis/comment/index.ts
+++ b/types/apis/comment/index.ts
@@ -37,7 +37,15 @@ export interface CommentEditExhibitionResponse extends BaseResponse {
   };
 }
 
+export interface CommentUpdateRequest {
+  content: string;
+}
+
 //댓글 생성
+export interface CommentCreateRequest {
+  content: string;
+  parentId?: number;
+}
 
 export interface CommentCreateExhibitionProps extends BaseResponse {
   data?: {

--- a/types/apis/user/index.ts
+++ b/types/apis/user/index.ts
@@ -1,7 +1,18 @@
-import { ExhibitionProps, ReviewProps, UserProps } from 'types/model';
+import { ExhibitionProps, ReviewProps } from 'types/model';
 import { BaseResponse } from '../base';
 
-export interface UserRegisterResponse extends BaseResponse {
+export interface UserLocalLoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface UserSignupRequest {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+export interface UserSignupResponse extends BaseResponse {
   data?: {
     userId: number;
     nickname: string;
@@ -47,10 +58,6 @@ export interface UserTokenResponse extends BaseResponse {
     accessToken: string;
   };
 }
-
-export type UserOauthLoginResponse = UserProps;
-
-export type UserLocalLoginResponse = UserProps;
 
 export interface UserCheckResponse extends BaseResponse {
   isUnique: boolean;

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,2 +1,3 @@
 export { displayDate, displayDday, displayFormattedDate } from './displayedAt';
+export { default as storage } from './storage';
 export { default as throttleOnRendering } from './throttleOnRendering';

--- a/utils/storage/index.ts
+++ b/utils/storage/index.ts
@@ -1,0 +1,18 @@
+const storage = {
+  getItem: <T>(key: string, initialValue: T) => {
+    const value = localStorage.getItem(key);
+    return value ? JSON.parse(value) : initialValue;
+  },
+  setItem: <T>(key: string, value: T) => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.error(error);
+    }
+  },
+  removeItem: (key: string) => {
+    localStorage.removeItem(key);
+  },
+};
+
+export default storage;


### PR DESCRIPTION
# 작업 내용 (TODO)

- [x] axios 공통 설정
- [x] 환경 변수 설정
- [x] 로컬 스토리지 유틸 함수 추가
- [x] user, exhibition, review, comment API 추가
- [x] API 요청 테스트 
- [x] useAxios 커스텀 훅 추가

## axios 공통 설정

apis 폴더 내부에 다음과 같이 폴더를 만들었습니다. 

![image](https://user-images.githubusercontent.com/80658269/183021571-33e7426e-d824-4180-9230-80a493bddc46.png)

common.ts를 통해 axios 공통 설정을 하였습니다. 

인증이 필요한 요청은 authRequest이고, 인증이 불필요한 요청은 unAuthRequest입니다.

authRequest는 로컬 스토리지에서 토큰을 꺼내 header에 추가합니다. 

![image](https://user-images.githubusercontent.com/80658269/183021830-9b6905e0-e8fd-496f-b499-c15b75b3b607.png)

## 환경 변수 설정
API_END_POINT를 환경변수로 설정하고 baseURL로 적용했습니다. 
![image](https://user-images.githubusercontent.com/80658269/183022002-ad3dab6f-5102-4d14-b73b-89bdf60b5aa7.png)

## 스토리지 유틸 함수 추가

utils 폴더에 로컬 스토리지 관련 유틸 함수를 추가했습니다. 

![image](https://user-images.githubusercontent.com/80658269/183022432-01dd21fd-71e3-4f39-a851-86b4ec335338.png)

getItem, setItem, removeItem이 있습니다. 

## user, exhibition, review, comment API 추가

도메인 별로 API를 추가했습니다. 
현재까지 구현 완료된 API들을 추가했습니다 (누락된 것도 있습니다)

## API 요청 테스트 

일반적으로 아래와 같이 요청해서 사용할 수 있습니다. 

```javascript
const data = await exhibitionAPI.getUpcoming(0, 5).then((res) => res.data);
```

![image](https://user-images.githubusercontent.com/80658269/183022899-c54694d7-cf99-418d-ad32-3c25d22e62a6.png)

## useAxios 커스텀 훅 추가

![image](https://user-images.githubusercontent.com/80658269/183023780-d73b134a-a157-4dbe-ad8d-771434757543.png)

useAxios 커스텀 훅을 사용한다면 
초기 상태, 로딩 중, 응답 완료 별로 데이터를 쉽게 받을 수 있습니다. 

```javascript
  const { response, isLoading, error } = useAxios(() => exhibitionAPI.getUpcoming(0, 5), []);
  console.log('response', response);
  console.log('isLoading', isLoading);
  console.log('error', error);
```


![axios](https://user-images.githubusercontent.com/80658269/183023154-e1144584-862e-4f9a-8194-43fb1e5118de.png)

단, 커스텀 훅이라서 사용에 제한이 있습니다. 
예를 들어, getStaticProps 등에서는 사용할 수 없습니다. 

적절히 사용하면 좋을 것 같습니다. 

## 논의하고 싶은 부분 

타입 정의에서 아래를 삭제해도 괜찮을까요? 
UserProps로 충분할 것 같다는 생각이 들어서입니다 :) 

```typescript
export type UserOauthLoginResponse = UserProps;
export type UserLocalLoginResponse = UserProps;
```

comment interface에서 네이밍 건의입니다. 

![image](https://user-images.githubusercontent.com/80658269/183025183-047df56f-f510-47c7-935e-5c55180dc066.png)

comment와 exhibition은 관련이 없지 않을까요? 

그리고 comment는 한 곳에서만 사용되기 때문에 
exhibition 또는 review 등을 붙이지 않아도 괜찮다고 생각합니다. 
어떻게 생각하시나요? 

close #104
