### PR TITLE
fix: API 명세 변경에 따른 타입 수정

### DIFF
--- a/components/molecule/ExhibitionCard/index.tsx
+++ b/components/molecule/ExhibitionCard/index.tsx
@@ -18,7 +18,7 @@ const ExhibitionCard = ({
   likeCount,
   reviewCount,
   isLiked,
-}: ExhibitionProps) => {
+}: Required<ExhibitionProps>) => {
   const [isHover, setIsHover] = useState(false);
   const mouseHover = () => setIsHover((isHover) => !isHover);
 

--- a/components/organism/ReviewDetail/index.tsx
+++ b/components/organism/ReviewDetail/index.tsx
@@ -14,6 +14,7 @@ const ReviewDetail = ({
   createdAt,
   user,
   exhibition,
+  date,
   title,
   isPublic,
   isEdited,

--- a/mocks/handlers/review/index.ts
+++ b/mocks/handlers/review/index.ts
@@ -13,8 +13,12 @@ const REVIEWS = {
       exhibition: {
         exhibitionId: 24,
         name: '전시회 이름',
-        startDate: '2022-10-11',
         thumbnail: 'https://www.culture.go.kr/upload/rdf/22/07/show_2022071816261910020.jpg',
+        startDate: '2022-08-04',
+        endDate: '2022-08-10',
+        isLiked: false,
+        likeCount: 5,
+        reviewCount: 3,
       },
       title: '리뷰 제목 (핸드아트)',
       content: '오늘 핸드아트코리아 전시회를 다녀왔다. 정말 재밌었다~~',
@@ -47,64 +51,72 @@ const REVIEWS = {
           path: 'https://source.unsplash.com/random?5',
         },
       ],
-      comments: [
-        {
-          commentId: 0,
-          content: '꼭 가고 싶네요. 근데 시간이 될지ㅠㅠ',
-          createdAt: '2022-07-26T11:26:24',
-          updatedAt: '2022-07-26T11:28:49',
-          isEdited: true,
-          isDeleted: false,
-          user: {
-            userId: 0,
-            nickname: '미스터공공1',
-            profileImage: 'https://joeschmoe.io/api/v1/random?5',
+      comments: {
+        content: [
+          {
+            commentId: 0,
+            content: '꼭 가고 싶네요. 근데 시간이 될지ㅠㅠ',
+            createdAt: '2022-07-26T11:26:24',
+            updatedAt: '2022-07-26T11:28:49',
+            isEdited: true,
+            isDeleted: false,
+            user: {
+              userId: 0,
+              nickname: '미스터공공1',
+              profileImage: 'https://joeschmoe.io/api/v1/random?5',
+            },
+            childrenCount: 1,
           },
-          childrenCount: 1,
-        },
-        {
-          commentId: 1,
-          content: '대댓글 기준 데이터',
-          createdAt: '2022-07-26T11:26:24',
-          updatedAt: '2022-07-26T11:28:49',
-          isEdited: true,
-          isDeleted: false,
-          user: {
-            userId: 0,
-            nickname: '미스터공공2',
-            profileImage: 'https://joeschmoe.io/api/v1/random?6',
+          {
+            commentId: 1,
+            content: '대댓글 기준 데이터',
+            createdAt: '2022-07-26T11:26:24',
+            updatedAt: '2022-07-26T11:28:49',
+            isEdited: true,
+            isDeleted: false,
+            user: {
+              userId: 0,
+              nickname: '미스터공공2',
+              profileImage: 'https://joeschmoe.io/api/v1/random?6',
+            },
+            childrenCount: 3,
           },
-          childrenCount: 3,
-        },
-        {
-          commentId: 2,
-          content: '꼭 가고 싶네요. 근데 시간이 될지ㅠㅠ',
-          createdAt: '2022-07-26T11:26:24',
-          updatedAt: '2022-07-26T11:28:49',
-          isEdited: true,
-          isDeleted: false,
-          user: {
-            userId: 0,
-            nickname: '미스터공공3',
-            profileImage: 'https://joeschmoe.io/api/v1/random?7',
+          {
+            commentId: 2,
+            content: '꼭 가고 싶네요. 근데 시간이 될지ㅠㅠ',
+            createdAt: '2022-07-26T11:26:24',
+            updatedAt: '2022-07-26T11:28:49',
+            isEdited: true,
+            isDeleted: false,
+            user: {
+              userId: 0,
+              nickname: '미스터공공3',
+              profileImage: 'https://joeschmoe.io/api/v1/random?7',
+            },
+            childrenCount: 1,
           },
-          childrenCount: 1,
-        },
-        {
-          commentId: 3,
-          content: '꼭 가고 싶네요. 근데 시간이 될지ㅠㅠ',
-          createdAt: '2022-07-26T11:26:24',
-          updatedAt: '2022-07-26T11:28:49',
-          isEdited: true,
-          isDeleted: false,
-          user: {
-            userId: 0,
-            nickname: '미스터공공4',
-            profileImage: 'https://joeschmoe.io/api/v1/random?8',
+          {
+            commentId: 3,
+            content: '꼭 가고 싶네요. 근데 시간이 될지ㅠㅠ',
+            createdAt: '2022-07-26T11:26:24',
+            updatedAt: '2022-07-26T11:28:49',
+            isEdited: true,
+            isDeleted: false,
+            user: {
+              userId: 0,
+              nickname: '미스터공공4',
+              profileImage: 'https://joeschmoe.io/api/v1/random?8',
+            },
+            childrenCount: 1,
           },
-          childrenCount: 1,
-        },
-      ],
+        ],
+      },
+      numberOfElements: 1,
+      offset: 0,
+      pageNumber: 0,
+      pageSize: 20,
+      totalElements: 1,
+      totalPages: 1,
     },
     {
       reviewId: 41,
@@ -197,16 +209,15 @@ const ReviewHandlers = [
       const new_review_data = REVIEWS.content.map((review) => {
         review.reviewId += Math.floor(Math.random() * 1000);
         review.title = '무한스크롤 더미'.concat(page);
-
+        // delete review.comments; 실제로는 빠져서 내려옴.
         return review;
       });
-
-      console.log('new_review_data', new_review_data);
 
       const new_multi_review_success = {
         message: '후기 다건 조회 성공',
         code: 200,
         data: {
+          // 빠지는 데이타
           ...new_review_data,
         },
       };

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -8,7 +8,7 @@ import { ReviewMultiReadResponse, ReviewSingleReadData } from 'types/apis/review
 import { ReviewFeed } from 'components/organism';
 
 const CommunityPage = ({ data }: ReviewMultiReadResponse) => {
-  const { totalPages } = data;
+  const { totalPages, content } = data;
   const [currentPage, setCurrentPage] = useState(0);
 
   const getMoreFeed = async () => {
@@ -25,7 +25,7 @@ const CommunityPage = ({ data }: ReviewMultiReadResponse) => {
   };
 
   const [fetching, setFetching] = useInfiniteScroll(getMoreFeed);
-  const [feeds, setFeeds] = useState([...data.content]);
+  const [feeds, setFeeds] = useState([...content]);
 
   return (
     <>

--- a/pages/reviews/detail/[id]/index.tsx
+++ b/pages/reviews/detail/[id]/index.tsx
@@ -19,6 +19,8 @@ const ReviewDetailPage = ({ data }: ReviewSingleReadResponse) => {
     createdAt,
     updatedAt,
     commentCount,
+    comments,
+    date,
   } = data;
 
   return (
@@ -39,6 +41,8 @@ const ReviewDetailPage = ({ data }: ReviewSingleReadResponse) => {
         photos={photos}
         updatedAt={updatedAt}
         exhibition={exhibition}
+        comments={comments}
+        date={date}
         user={user}
         onDeleteButtonClick={() => {
           console.log('삭제!');

--- a/types/apis/review/index.ts
+++ b/types/apis/review/index.ts
@@ -1,5 +1,5 @@
 import { ExhibitionProps, UserProps, PhotoProps, CommentProps } from 'types/model';
-import { BaseResponse } from '../base';
+import { BaseResponse, PaginationResponse } from '../base';
 
 // 후기 생성
 export interface ReviewIdData {
@@ -20,6 +20,7 @@ export interface ReviewSingleReadData {
   reviewId: number;
   user: UserProps;
   exhibition: ExhibitionProps;
+  date: string;
   title: string;
   content: string;
   createdAt: string;
@@ -30,7 +31,7 @@ export interface ReviewSingleReadData {
   likeCount: number;
   commentCount: number;
   photos: PhotoProps[];
-  comments?: CommentProps;
+  comments: PaginationResponse<CommentProps>;
 }
 
 export interface ReviewSingleReadResponse extends BaseResponse {
@@ -39,7 +40,7 @@ export interface ReviewSingleReadResponse extends BaseResponse {
 
 // 후기 다건 조회
 export interface ReviewMultiReadData {
-  content: ReviewSingleReadData[];
+  content: Omit<ReviewSingleReadData, 'comment'>[];
   numberOfElements: number; //content의 요소가 몇개인지
   offset: number; // 현재 페이지에서 시작하는 요소의 index 번호
   pageNumber: number; //페이지 넘버

--- a/types/model.ts
+++ b/types/model.ts
@@ -2,11 +2,11 @@ export interface ExhibitionProps {
   exhibitionId: number;
   name: string;
   thumbnail: string;
-  startDate: string;
-  endDate: string;
-  likeCount: number;
-  reviewCount: number;
-  isLiked: boolean;
+  startDate?: string;
+  endDate?: string;
+  likeCount?: number;
+  reviewCount?: number;
+  isLiked?: boolean;
 }
 
 export interface ReviewFeedProps {


### PR DESCRIPTION
# 작업 내용 (TODO)

API 명세 변경에 따른 타입을 수정하였습니다.

- [x] 후기 단건 조회
- [x] 후기 다건 조회

# 사진 (구현 캡쳐)
```typescript
// 후기 단건 조회
export interface ReviewSingleReadData {
  reviewId: number;
  user: UserProps;
  exhibition: ExhibitionProps;
  date: string; // 명세에서 누락되었던 부분
  title: string;
  content: string;
  createdAt: string;
  updatedAt: number;
  isEdited: boolean;
  isLiked: boolean;
  isPublic: boolean;
  likeCount: number;
  commentCount: number;
  photos: PhotoProps[];
  comments: PaginationResponse<CommentProps>; // 명세가 변경된 부분
}
```

```typescript
// 후기 다건 조회
export interface ReviewMultiReadData {
  content: Omit<ReviewSingleReadData, 'comment'>[]; 
  numberOfElements: number; 
  offset: number; 
  pageNumber: number; 
  pageSize: number;
  totalElements: number;
  totalPages: number;
}
```

```typescript
// 바뀐 exhibition props
export interface ExhibitionProps {
  exhibitionId: number;
  name: string;
  thumbnail: string;
// 추가된 부분  후기 다건에서는 내려오지 않음
  startDate?: string;
  endDate?: string;
  likeCount?: number;
  reviewCount?: number;
  isLiked?: boolean;
}
```
# 논의하고 싶은 부분

close #126 

