### PR TITLE
feat: 로컬 로그인 token 저장

### DIFF
--- a/pages/signin/index.tsx
+++ b/pages/signin/index.tsx
@@ -16,6 +16,7 @@ const SignInPage = () => {
       storage.setItem<string>('ACCESS_TOKEN', accessToken);
       cookie.setItem<string>('REFRESH_TOKEN', refreshToken);
       alert(res.data.message);
+      Router.push('/');
       // eslint-disable-next-line
     } catch (e: any) {
       e.message = 'SigninError';

--- a/pages/signin/index.tsx
+++ b/pages/signin/index.tsx
@@ -2,8 +2,25 @@ import styled from '@emotion/styled';
 import { Button, Checkbox, Form, Image, Input } from 'antd';
 import Head from 'next/head';
 import Link from 'next/link';
+import { UserLocalLoginRequest } from 'types/apis/user';
+import { userAPI } from 'apis';
+import { storage, cookie } from 'utils';
+import Router from 'next/router';
 
 const SignInPage = () => {
+  const onFinish = async (values: UserLocalLoginRequest) => {
+    try {
+      const res = await userAPI.localLogin(values);
+      const { accessToken, refreshToken } = res.data.data;
+      console.log(accessToken, refreshToken);
+      storage.setItem<string>('ACCESS_TOKEN', accessToken);
+      cookie.setItem<string>('REFRESH_TOKEN', refreshToken);
+      // eslint-disable-next-line
+    } catch (e: any) {
+      e.message = 'SigninError';
+      throw e;
+    }
+  };
   return (
     <>
       <Head>
@@ -15,11 +32,13 @@ const SignInPage = () => {
           <Logo>Art.zip</Logo>
         </Link>
         <Title>로그인</Title>
-        <Form name="basic" initialValues={{ remember: true }} autoComplete="off">
-          <Form.Item
-            name="username"
-            rules={[{ required: true, message: '!이메일을 입력해 주세요' }]}
-          >
+        <Form
+          name="basic"
+          initialValues={{ remember: true }}
+          autoComplete="off"
+          onFinish={onFinish}
+        >
+          <Form.Item name="email" rules={[{ required: true, message: '!이메일을 입력해 주세요' }]}>
             <StyledInput placeholder="이메일을 입력해 주세요" />
           </Form.Item>
 

--- a/pages/signin/index.tsx
+++ b/pages/signin/index.tsx
@@ -15,9 +15,11 @@ const SignInPage = () => {
       console.log(accessToken, refreshToken);
       storage.setItem<string>('ACCESS_TOKEN', accessToken);
       cookie.setItem<string>('REFRESH_TOKEN', refreshToken);
+      alert(res.data.message);
       // eslint-disable-next-line
     } catch (e: any) {
       e.message = 'SigninError';
+      alert(e.response.data.message);
       throw e;
     }
   };

--- a/utils/cookie/index.ts
+++ b/utils/cookie/index.ts
@@ -8,6 +8,7 @@ const cookie = {
       document.cookie =
         encodeURIComponent(key) +
         '=' +
+        // eslint-disable-next-line
         encodeURIComponent(JSON.stringify(value).replace(/\"/gi, ''));
     } catch (error) {
       console.error(error);

--- a/utils/cookie/index.ts
+++ b/utils/cookie/index.ts
@@ -1,0 +1,21 @@
+const cookie = {
+  getItem: <T>(key: string, initialValue: T) => {
+    const value = document.cookie.match('(^|;) ?' + key + '=([^;]*)(;|$)');
+    return value ? value[2] : initialValue;
+  },
+  setItem: <T>(key: string, value: T) => {
+    try {
+      document.cookie =
+        encodeURIComponent(key) +
+        '=' +
+        encodeURIComponent(JSON.stringify(value).replace(/\"/gi, ''));
+    } catch (error) {
+      console.error(error);
+    }
+  },
+  removeItem: (key: string) => {
+    document.cookie = encodeURIComponent(key);
+  },
+};
+
+export default cookie;

--- a/utils/cookie/index.ts
+++ b/utils/cookie/index.ts
@@ -15,7 +15,7 @@ const cookie = {
     }
   },
   removeItem: (key: string) => {
-    document.cookie = encodeURIComponent(key);
+    document.cookie = encodeURIComponent(key) + '=; expires=Thu, 01 JAN 1999 00:00:10 GMT';
   },
 };
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,4 @@
 export { displayDate, displayDday, displayFormattedDate } from './displayedAt';
 export { default as storage } from './storage';
+export { default as cookie } from './cookie';
 export { default as throttleOnRendering } from './throttleOnRendering';


### PR DESCRIPTION
# 작업 내용 (TODO)
- [x] 쿠키 유틸 함수 추가(getItem, setItem, removeItem)
- [x]  액세스 토큰 로컬 스토리지 저장
- [x] 리프레시 토큰 쿠키 저장

# 사진 (구현 캡쳐)
쿠키는 로컬 스토리지처럼 따로 함수를 제공하지 않고 
"name=value;만료기간" 으로 문자열을 조정해서 사용해야 했습니다.
쿠키를 써본건 처음이라 구현이 늦어진 점 죄송합니다 ㅜㅜ

다른 분이 쓰실 일이 있을지는 모르지만 일단 공공이 구현한 storage와 최대한 비슷하게 만들었습니당.

https://user-images.githubusercontent.com/93373357/183500843-075b27ec-4ed3-4821-aae6-3ac60d57e4f1.mp4

getItem
![image](https://user-images.githubusercontent.com/93373357/183501005-566f0ca8-db43-4175-9060-475169048fe9.png)

setItem
![image](https://user-images.githubusercontent.com/93373357/183501084-bdac8393-3af1-4879-9a46-49c66e11aae2.png)

removeItem
![image](https://user-images.githubusercontent.com/93373357/183501139-ec5d14c8-380a-4298-a261-e73531a0ec54.png)

# 논의하고 싶은 부분
1. 제네릭 타입 때문에 value를 JSON.stringify해서 사용해야 합니다. 이 때문에 토큰 앞뒤로 큰 따옴표가 붙어서 encodeURL 에 문제가 생기기 때문에 replace를 합니다. 이 과정에서 eslint  `no-useless-escape` 에러가 떠서 일단 저렇게 막아놨는데 다른 방법이 있을까요?
![image](https://user-images.githubusercontent.com/93373357/183501699-224bf0b4-4aeb-4000-83aa-020be45df6e2.png)
2. 로그인 폼 제출시 onFinish 함수 구현에 try/catch문을 사용하였는데 catch에서 에러의 타입 처리를 어떻게 하면 좋을지 잘 모르겠습니다 ㅜㅜ 저것도 일단은 그냥 any로 두었습니다.
![image](https://user-images.githubusercontent.com/93373357/183501791-fd0825d8-72d8-410e-bef4-46db422bd865.png)
3. 일단은 따로 리프레시 토큰의 만료기간을 설정하지 않은 상태입니다. 백엔드 분들과 만료 기간에 대해서 논의한 후 현재 시간을 기준으로 특정 시간 후 까지로 설정하면 될 것 같은데 괜찮을까요 ?




close #131 