### PR TITLE
feat: exhibitionCard css 수정

### DIFF
--- a/components/molecule/ExhibitionCard/index.tsx
+++ b/components/molecule/ExhibitionCard/index.tsx
@@ -27,7 +27,7 @@ const ExhibitionCard = ({
     setDDay(displayDday(startDate));
     if (dDay < 0) {
       setIsOverDDay(true);
-      setDDay(dDay * -1);
+      setDDay(Math.abs(dDay));
     }
   }, []);
   return (

--- a/components/molecule/ExhibitionCard/index.tsx
+++ b/components/molecule/ExhibitionCard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Card, Image } from 'antd';
 import { HeartFilled, HeartOutlined, MessageOutlined } from '@ant-design/icons';
 import * as S from './style';
@@ -19,13 +19,22 @@ const ExhibitionCard = ({
   isLiked,
 }: Required<ExhibitionProps>) => {
   const [isHover, setIsHover] = useState(false);
+  const [isOverDDay, setIsOverDDay] = useState(false);
+  const [dDay, setDDay] = useState(0);
   const mouseHover = () => setIsHover((isHover) => !isHover);
 
+  useEffect(() => {
+    setDDay(displayDday(startDate));
+    if (dDay < 0) {
+      setIsOverDDay(true);
+      setDDay(dDay * -1);
+    }
+  }, []);
   return (
     <Link href={`exhibitions/detail/${exhibitionId}`}>
       <S.ExhibitionCard>
         <Card
-          hoverable
+          className="exhibition-card"
           extra={
             isHover ? (
               <S.HoverContent>
@@ -37,12 +46,7 @@ const ExhibitionCard = ({
           }
           onMouseEnter={mouseHover}
           onMouseLeave={mouseHover}
-          style={{
-            width: '100%',
-            height: '85%',
-            position: 'relative',
-          }}
-          cover={<Image alt="card image" src={thumbnail} className="card-image" />}
+          cover={<Image alt="card image" src={thumbnail} className="card-image" preview={false} />}
         />
         <S.Description>
           <h3>{name}</h3>
@@ -50,7 +54,10 @@ const ExhibitionCard = ({
             <h3>
               {displayFormattedDate(startDate)} - {displayFormattedDate(endDate)}
             </h3>
-            <S.Dday>D-{displayDday(startDate)}</S.Dday>
+            <S.Dday>
+              D{isOverDDay ? '+' : '-'}
+              {dDay}
+            </S.Dday>
           </div>
         </S.Description>
       </S.ExhibitionCard>

--- a/components/molecule/ExhibitionCard/index.tsx
+++ b/components/molecule/ExhibitionCard/index.tsx
@@ -19,35 +19,26 @@ const ExhibitionCard = ({
   isLiked,
 }: Required<ExhibitionProps>) => {
   const [isHover, setIsHover] = useState(false);
-  const [isOverDDay, setIsOverDDay] = useState(false);
-  const [dDay, setDDay] = useState(0);
+  const dDay = displayDday(startDate);
   const mouseHover = () => setIsHover((isHover) => !isHover);
 
-  useEffect(() => {
-    setDDay(displayDday(startDate));
-    if (dDay < 0) {
-      setIsOverDDay(true);
-      setDDay(Math.abs(dDay));
-    }
-  }, []);
   return (
     <Link href={`exhibitions/detail/${exhibitionId}`}>
       <S.ExhibitionCard>
         <Card
           className="exhibition-card"
-          extra={
-            isHover ? (
-              <S.HoverContent>
-                {' '}
-                {isLiked ? <HeartFilled className="heart-icon" /> : <HeartOutlined />}
-                {likeCount} <MessageOutlined /> {reviewCount}{' '}
-              </S.HoverContent>
-            ) : null
-          }
           onMouseEnter={mouseHover}
           onMouseLeave={mouseHover}
           cover={<Image alt="card image" src={thumbnail} className="card-image" preview={false} />}
-        />
+        >
+          {isHover && (
+            <S.HoverContent>
+              {' '}
+              {isLiked ? <HeartFilled className="heart-icon" /> : <HeartOutlined />}
+              {likeCount} <MessageOutlined /> {reviewCount}{' '}
+            </S.HoverContent>
+          )}
+        </Card>
         <S.Description>
           <h3 className="title">{name}</h3>
           <div>
@@ -55,8 +46,8 @@ const ExhibitionCard = ({
               {displayFormattedDate(startDate)} - {displayFormattedDate(endDate)}
             </h3>
             <S.Dday>
-              D{isOverDDay ? '+' : '-'}
-              {dDay}
+              D{dDay < 0 ? '+' : '-'}
+              {Math.abs(dDay)}
             </S.Dday>
           </div>
         </S.Description>

--- a/components/molecule/ExhibitionCard/index.tsx
+++ b/components/molecule/ExhibitionCard/index.tsx
@@ -49,7 +49,7 @@ const ExhibitionCard = ({
           cover={<Image alt="card image" src={thumbnail} className="card-image" preview={false} />}
         />
         <S.Description>
-          <h3>{name}</h3>
+          <h3 className="title">{name}</h3>
           <div>
             <h3>
               {displayFormattedDate(startDate)} - {displayFormattedDate(endDate)}

--- a/components/molecule/ExhibitionCard/style.ts
+++ b/components/molecule/ExhibitionCard/style.ts
@@ -5,13 +5,22 @@ export const ExhibitionCard = styled.div`
   box-shadow: 0px 6px 8px rgba(0, 0, 0, 0.25);
   border-radius: 8px;
   width: 250px;
-  height: 350px;
+  height: 400px;
   margin-top: 20px;
   padding-bottom: 20px;
   &:hover {
-    .card-image {
+    .exhibition-card {
       filter: brightness(70%);
     }
+  }
+
+  .card-image {
+    max-height: 300px;
+    min-height: 300px;
+  }
+
+  .ant-card-body {
+    padding: 0px;
   }
 `;
 

--- a/components/molecule/ExhibitionCard/style.ts
+++ b/components/molecule/ExhibitionCard/style.ts
@@ -47,6 +47,11 @@ export const Description = styled.div`
   padding-top: 5px;
   padding-left: 10px;
   padding-bottom: 5px;
+
+  .title {
+    white-space: nowrap;
+    overflow: hidden;
+  }
   div {
     display: flex;
     align-items: center;

--- a/components/molecule/ExhibitionCard/style.ts
+++ b/components/molecule/ExhibitionCard/style.ts
@@ -8,10 +8,11 @@ export const ExhibitionCard = styled.div`
   height: 400px;
   margin-top: 20px;
   padding-bottom: 20px;
+
+  position: relative;
+
   &:hover {
-    .exhibition-card {
-      filter: brightness(70%);
-    }
+    filter: brightness(50%);
   }
 
   .card-image {
@@ -24,7 +25,7 @@ export const ExhibitionCard = styled.div`
   }
 
   .ant-card-head {
-    display: none;
+    height: 0px;
   }
 `;
 
@@ -42,6 +43,7 @@ export const HoverContent = styled.div`
   left: 50%;
   transform: translate(-50%, -50%);
   opacity: 1;
+  font-weight: 700;
   .heart-icon {
     color: ${({ theme }) => theme.color.red};
   }

--- a/components/molecule/ExhibitionCard/style.ts
+++ b/components/molecule/ExhibitionCard/style.ts
@@ -22,6 +22,10 @@ export const ExhibitionCard = styled.div`
   .ant-card-body {
     padding: 0px;
   }
+
+  .ant-card-head {
+    display: none;
+  }
 `;
 
 export const HoverContent = styled.div`

--- a/components/organism/Swiper/style.ts
+++ b/components/organism/Swiper/style.ts
@@ -4,9 +4,11 @@ export const SwiperWrapper = styled.div`
   padding: 10px;
   position: relative;
   margin-bottom: 30px;
+  height: 500px;
 
   .swiper-container {
     width: 80%;
+    height: 500px;
     padding-left: 50px;
     padding-right: 50px;
   }


### PR DESCRIPTION
# 작업 내용 (TODO)

- [x] ExhibitionCard css 수정
- [x] startDate가 오늘 날짜를 이미 지나친 경우 d-day를 + 로 출력 

# 사진 (구현 캡쳐)
![스크린샷 2022-08-10 오후 9 53 18](https://user-images.githubusercontent.com/72402747/183906144-11c08f9f-ce48-4c83-bf79-b274881c197c.png)


# 논의하고 싶은 부분
antd 의 image를 쓰실 때 hover 하면 위에 공간이 생깁니다.
이 때 다음 속성을 css 에 추가해주시면 바로 해결 가능합니당

```
  .ant-card-head {
    height: 0px;
  }
```

close #125
