### PR TITLE
feat: 커뮤니티 페이지, 후기 상세 페이지 Read 관련 api 연결 

### DIFF
--- a/apis/comment/index.ts
+++ b/apis/comment/index.ts
@@ -1,4 +1,4 @@
-import { authRequest } from 'apis/common';
+import { authRequest, unAuthRequest } from 'apis/common';
 import { CommentCreateRequest, CommentUpdateRequest } from 'types/apis/comment';
 
 const commentAPI = {
@@ -10,6 +10,9 @@ const commentAPI = {
   },
   delete: (commentId: number) => {
     authRequest.delete(`/api/v1/comments/${commentId}`);
+  },
+  getReplies: (commentId: number, pages?: number, size?: number) => {
+    return unAuthRequest.get(`/api/v1/comments/${commentId}/children?page=${pages}&size=${size}`);
   },
 };
 

--- a/apis/review/index.ts
+++ b/apis/review/index.ts
@@ -4,11 +4,24 @@ const reviewAPI = {
   likeToggle: (reviewId: number) => {
     return authRequest.patch(`/api/v1/reviews/${reviewId}/like`);
   },
-  getComments: (reviewId: number, page: number, size: number) => {
+  getComments: (reviewId: number, page?: number, size?: number) => {
     return unAuthRequest.get(`/api/v1/reviews/${reviewId}/comments?page=${page}&size=${size}`);
   },
   searchExhibition: (query: string) => {
     return unAuthRequest.get(`/api/v1/reviews/search/exhibitions?query=${query}`);
+  },
+  getReviewMulti: (exhibitionId?: number, page?: number, size?: number, sort?: string) => {
+    return unAuthRequest.get(`/api/v1/reviews`, {
+      params: {
+        ...(exhibitionId ? { exhibitionId: exhibitionId } : {}),
+        ...(page ? { page: page } : {}),
+        ...(size ? { size: size } : {}),
+        ...(sort ? { sort: sort } : {}),
+      },
+    });
+  },
+  getReviewSingle: (reviewId: number) => {
+    return unAuthRequest.get(`/api/v1/reviews/${reviewId}`);
   },
 };
 

--- a/components/organism/CommentList/index.tsx
+++ b/components/organism/CommentList/index.tsx
@@ -2,13 +2,13 @@ import { CommentProps } from 'types/model';
 import { PaginationResponse } from 'types/apis/base';
 import { useInfiniteScroll } from 'hooks';
 import { useState } from 'react';
-import { Comment, Tooltip } from 'antd';
 import Link from 'next/link';
+import { Comment, Tooltip } from 'antd';
 import { UserAvatar } from 'components/atom';
 import { CommentUtils } from 'components/organism';
 import moment from 'moment';
 import { displayDate } from 'utils';
-import axios from 'axios';
+import reviewAPI from 'apis/review';
 
 const CommentList = ({
   comments,
@@ -18,16 +18,10 @@ const CommentList = ({
   reviewId: number;
 }) => {
   const getMoreComment = async () => {
-    if (totalPages <= currentPage) {
+    if (totalPage <= currentPage) {
       return;
     }
-
-    const { data } = await axios.get(
-      `${process.env.MOCKING_API_END_POINT}api/v1/reviews/${reviewId}/comments?page=${
-        currentPage + 1
-      }`,
-    );
-
+    const { data } = await reviewAPI.getComments(reviewId, currentPage + 1);
     const newComments: CommentProps[] = Object.values(data.data);
     setCurrentComments([...currentComments, ...newComments]);
     setCurrentPage(currentPage + 1);
@@ -37,7 +31,7 @@ const CommentList = ({
   const [fetching, setFetching] = useInfiniteScroll(getMoreComment);
   const [currentComments, setCurrentComments] = useState(comments.content);
 
-  const { totalPages } = comments;
+  const { totalPage } = comments;
 
   return (
     <>

--- a/components/organism/CommentUtils/index.tsx
+++ b/components/organism/CommentUtils/index.tsx
@@ -9,6 +9,7 @@ import Link from 'next/link';
 import { UserAvatar } from 'components/atom';
 import moment from 'moment';
 import { displayDate } from 'utils';
+import { commentAPI } from 'apis';
 
 const CommentUtils = ({ comment }: { comment: CommentProps }) => {
   // TODO: 로그인한 유저의 상태, 후에 전역 상태로 판단
@@ -41,9 +42,7 @@ const CommentUtils = ({ comment }: { comment: CommentProps }) => {
   };
 
   const getReply = async () => {
-    const { data } = await axios.get(
-      `${process.env.MOCKING_API_END_POINT}api/v1/comments/${commentId}/children`,
-    );
+    const { data } = await commentAPI.getReplies(commentId);
 
     const newReplies: CommentProps[] = Object.values(data.data.content);
     setReplyList([...replyList, ...newReplies]);

--- a/components/organism/ReviewFeed/index.tsx
+++ b/components/organism/ReviewFeed/index.tsx
@@ -1,5 +1,6 @@
 import { UserInfo } from 'components/molecule';
 import styled from '@emotion/styled';
+import * as S from './style';
 import { Card, Button, Image } from 'antd';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -7,55 +8,51 @@ import { ReviewFeedProps } from 'types/model';
 import { InfoGroup } from 'components/organism';
 import { LinkButton } from 'components/atom';
 
-const ReviewFeed = ({
-  userProfileImage,
-  userName,
-  userId,
-  feedCreateDate,
-  exhibitionName,
-  exhibitionId,
-  feedTitle,
-  feedContent,
-  isLiked,
-  likeCount,
-  onLikeClick,
-  commentCount,
-  isMyFeed,
-  reviewId,
-  onDeleteButtonClick,
-  reviewThumbnailImage,
-}: ReviewFeedProps) => {
+const ReviewFeed = ({ feed, isMyFeed, onLikeClick, onDeleteButtonClick }: ReviewFeedProps) => {
   const router = useRouter();
 
+  const {
+    exhibition,
+    reviewId,
+    isLiked,
+    likeCount,
+    title,
+    content,
+    createdAt,
+    user,
+    commentCount,
+    photos,
+  } = feed;
+
   return (
-    <ReviewFeedCard>
-      <ReviewFeedWrapper>
-        <ReviewFeedContent>
-          <ReviewFeedHeader>
+    <S.ReviewFeedCard>
+      <S.ReviewFeedWrapper>
+        <S.ReviewFeedContent>
+          <S.ReviewFeedHeader>
             <UserInfo
-              profileImage={userProfileImage}
-              nickname={userName}
-              createdDate={feedCreateDate}
-              userId={userId}
+              profileImage={user.profileImage}
+              nickname={user.nickname}
+              createdDate={createdAt}
+              userId={user.userId}
             ></UserInfo>
-            <Link href={`/exhibitions/detail/${exhibitionId}`}>
+            <Link href={`/exhibitions/detail/${exhibition.exhibitionId}`}>
               <a>
-                <ReviewTagText># {exhibitionName}</ReviewTagText>
+                <S.ReviewTagText># {exhibition.name}</S.ReviewTagText>
               </a>
             </Link>
-          </ReviewFeedHeader>
+          </S.ReviewFeedHeader>
 
-          <ReviewFeedMainWrapper>
-            <ReviewFeedMain
+          <S.ReviewFeedMainWrapper>
+            <S.ReviewFeedMain
               onClick={() => {
                 router.push(`/reviews/detail/${reviewId}`);
               }}
             >
-              <ReviewTitle>{feedTitle}</ReviewTitle>
-              <ReviewContent>{feedContent}</ReviewContent>
-            </ReviewFeedMain>
+              <S.ReviewTitle>{title}</S.ReviewTitle>
+              <S.ReviewContent>{content}</S.ReviewContent>
+            </S.ReviewFeedMain>
 
-            <ReviewFeedBottom>
+            <S.ReviewFeedBottom>
               <InfoGroup
                 isLiked={isLiked}
                 likeCount={likeCount}
@@ -64,110 +61,33 @@ const ReviewFeed = ({
               />
 
               {isMyFeed && (
-                <FeedButtonGroup>
+                <S.FeedButtonGroup>
                   <LinkButton href={`/reviews/${reviewId}/edit`}>수정</LinkButton>
                   <Button type="text" onClick={onDeleteButtonClick}>
                     삭제
                   </Button>
-                </FeedButtonGroup>
+                </S.FeedButtonGroup>
               )}
-            </ReviewFeedBottom>
-          </ReviewFeedMainWrapper>
-        </ReviewFeedContent>
+            </S.ReviewFeedBottom>
+          </S.ReviewFeedMainWrapper>
+        </S.ReviewFeedContent>
 
-        <ReviewFeedThumbnail
+        <S.ReviewFeedThumbnail
           onClick={() => {
             router.push(`/reviews/detail/${reviewId}`);
           }}
         >
           <Image
-            src={reviewThumbnailImage}
+            src={photos.length ? photos[0].path : exhibition.thumbnail}
             width={150}
             height={150}
             preview={false}
             alt="Review Thumbnail"
           />
-        </ReviewFeedThumbnail>
-      </ReviewFeedWrapper>
-    </ReviewFeedCard>
+        </S.ReviewFeedThumbnail>
+      </S.ReviewFeedWrapper>
+    </S.ReviewFeedCard>
   );
 };
-
-const ReviewFeedCard = styled(Card)`
-  margin: 30px 0;
-`;
-
-const ReviewFeedWrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
-  &:hover {
-    cursor: pointer;
-  }
-`;
-
-const ReviewFeedContent = styled.div`
-  flex-grow: 1;
-  margin-right: 10px;
-`;
-
-const ReviewFeedThumbnail = styled.div`
-  &:hover {
-    filter: brightness(80%);
-  }
-`;
-
-const ReviewFeedHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-`;
-
-const ReviewTagText = styled.p`
-  font-size: 24px;
-  color: ${({ theme }) => theme.color.blue.main};
-
-  &:hover {
-    color: ${({ theme }) => theme.color.blue.dark};
-  }
-`;
-
-const ReviewFeedMainWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-`;
-
-const ReviewFeedMain = styled.div`
-  display: flex;
-  flex-direction: column;
-
-  &:hover {
-    text-decoration: underline;
-  }
-`;
-
-const ReviewTitle = styled.p`
-  font-size: 2.2rem;
-  margin-top: 10px;
-  font-weight: bold;
-`;
-
-const ReviewContent = styled.p`
-  display: -webkit-box;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-`;
-
-const ReviewFeedBottom = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-content: center;
-`;
-
-const FeedButtonGroup = styled.div`
-  display: flex;
-  align-content: center;
-`;
 
 export default ReviewFeed;

--- a/components/organism/ReviewFeed/style.ts
+++ b/components/organism/ReviewFeed/style.ts
@@ -1,0 +1,79 @@
+import styled from '@emotion/styled';
+import { Card } from 'antd';
+
+export const ReviewFeedCard = styled(Card)`
+  margin: 30px 0;
+`;
+
+export const ReviewFeedWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+export const ReviewFeedContent = styled.div`
+  flex-grow: 1;
+  margin-right: 10px;
+`;
+
+export const ReviewFeedThumbnail = styled.div`
+  &:hover {
+    filter: brightness(80%);
+  }
+`;
+
+export const ReviewFeedHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const ReviewTagText = styled.p`
+  font-size: 24px;
+  color: ${({ theme }) => theme.color.blue.main};
+
+  &:hover {
+    color: ${({ theme }) => theme.color.blue.dark};
+  }
+`;
+
+export const ReviewFeedMainWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const ReviewFeedMain = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+export const ReviewTitle = styled.p`
+  font-size: 2.2rem;
+  margin-top: 10px;
+  font-weight: bold;
+`;
+
+export const ReviewContent = styled.p`
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+`;
+
+export const ReviewFeedBottom = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-content: center;
+`;
+
+export const FeedButtonGroup = styled.div`
+  display: flex;
+  align-content: center;
+`;

--- a/pages/reviews/detail/[id]/index.tsx
+++ b/pages/reviews/detail/[id]/index.tsx
@@ -1,8 +1,8 @@
 import Head from 'next/head';
 import { GetServerSidePropsContext } from 'next';
-import axios from 'axios';
 import { ReviewDetail, CommentWrite, CommentList } from 'components/organism';
 import { ReviewSingleReadResponse } from 'types/apis/review';
+import { reviewAPI } from 'apis';
 
 const ReviewDetailPage = ({ data }: ReviewSingleReadResponse) => {
   const {
@@ -48,6 +48,7 @@ const ReviewDetailPage = ({ data }: ReviewSingleReadResponse) => {
         }}
       />
 
+      {/* 전역 상태 머지 되면 로직 구현 */}
       <CommentWrite user={undefined} />
       <CommentList comments={comments} reviewId={reviewId} />
     </>
@@ -59,13 +60,12 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
     return;
   }
 
-  // TODO: 실패했을 때, 성공했을 때 나눠서 응답값을 받아야 함
   const { id } = context.params;
-  const { data } = await axios.get(`${process.env.MOCKING_API_END_POINT}api/v1/reviews/${id}`);
+  const { data } = await reviewAPI.getReviewSingle(Number(id));
 
   return {
     props: {
-      data: data.data[0],
+      data: data.data,
     },
   };
 };

--- a/types/apis/base.ts
+++ b/types/apis/base.ts
@@ -11,5 +11,5 @@ export interface PaginationResponse<T> {
   pageNumber: number; //페이지 넘버
   pageSize: number; //페이지 사이즈
   totalElements: number; // 전체 요소 수
-  totalPages: number;
+  totalPage: number;
 }

--- a/types/model.ts
+++ b/types/model.ts
@@ -1,3 +1,4 @@
+import { ReviewSingleReadData } from './apis/review/index';
 export interface ExhibitionProps {
   exhibitionId: number;
   name: string;
@@ -10,22 +11,10 @@ export interface ExhibitionProps {
 }
 
 export interface ReviewFeedProps {
-  userProfileImage: string;
-  userName: string;
-  userId: number;
-  feedCreateDate: string;
-  exhibitionName: string;
-  exhibitionId: number;
-  feedTitle: string;
-  feedContent: string;
-  isLiked: boolean;
-  likeCount: number;
-  onLikeClick: () => void;
-  commentCount: number;
+  feed: ReviewSingleReadData;
   isMyFeed: boolean;
-  reviewId: number;
+  onLikeClick: () => void;
   onDeleteButtonClick: () => void;
-  reviewThumbnailImage: string;
 }
 
 export interface ReviewProps {


### PR DESCRIPTION
# 작업 내용 (TODO)

- **각 페이지 API 연결**
- [x] 커뮤니티 - 후기 다건 조회 
- [x] 리뷰 상세 - 후기 단건 조회
- [x] 리뷰 상세 - 댓글 조회

- **그 외**
- [x] `ReviewFeed` 컴포넌트 리팩터링

# 사진 (구현 캡쳐)

- **커뮤니티 페이지** : `/community`
![image](https://user-images.githubusercontent.com/74234333/184008534-385777ed-07b5-4acb-8823-64a7a20cc9c3.png)

- **전시회별 리뷰 모아보기** : `/community?exhibitionId={exhibitionId}`
![image](https://user-images.githubusercontent.com/74234333/184008800-d38592da-c514-44bf-a3db-531110688653.png)

- **리뷰 상세 조회** : `reviews/detail/{reviewId}`
![image](https://user-images.githubusercontent.com/74234333/184009004-8d187d72-1ee4-4e6c-b360-11056887948a.png)

# 논의하고 싶은 부분

제가 맡고 있는 페이지의 경우, 페이지의 로직 구현은 로그인 상태를 알아야 할 수 있으므로... 
전역 상태 PR이 머지되면 구현하도록 하겠습니다!

기능 구현 완료 후 css 조금 더 손 볼게요! 

close #137 
