### PR TITLE
feat: 유저페이지 API 연동하여 기능 구현

### DIFF
--- a/apis/user/index.ts
+++ b/apis/user/index.ts
@@ -9,7 +9,7 @@ const userAPI = {
     return unAuthRequest.post(`api/v1/users/oauth/login?code=${code}`);
   },
   signUp: (payload: UserSignupRequest) => {
-    return unAuthRequest.post('api/v1/users/signup', payload);
+    return unAuthRequest.post('api/v1/users/register', payload);
   },
   logout: () => {
     return unAuthRequest.patch('/api/v1/users/logout');
@@ -17,11 +17,22 @@ const userAPI = {
   nicknameCheck: (nickname: string) => {
     return unAuthRequest.get(`/api/v1/users/check?nickname=${nickname}`);
   },
-  getUserInfo: (userId: number) => {
-    return unAuthRequest.get(`api/v1/users/${userId}/info`);
-  },
   reissueToken: (payload: UserReissueTokenRequest) => {
     return authRequest.post(`api/v1/users/token/reissue`, payload);
+  },
+  getInformation: (userId: number) => {
+    return unAuthRequest.get(`/api/v1/users/${userId}/info`);
+  },
+  getMyReview: (userId: number, page: number, size: number) => {
+    return unAuthRequest.get(`/api/v1/users/${userId}/info/my/reviews?page=${page}&size=${size}`);
+  },
+  getLikeReview: (userId: number, page: number, size: number) => {
+    return unAuthRequest.get(`/api/v1/users/${userId}/info/reviews/like?page=${page}&size=${size}`);
+  },
+  getLikeExhibition: (userId: number, page: number, size: number) => {
+    return unAuthRequest.get(
+      `/api/v1/users/${userId}/info/exhibitions/like?page=${page}&size=${size}`,
+    );
   },
 };
 

--- a/apis/user/index.ts
+++ b/apis/user/index.ts
@@ -9,7 +9,7 @@ const userAPI = {
     return unAuthRequest.post(`api/v1/users/oauth/login?code=${code}`);
   },
   signUp: (payload: UserSignupRequest) => {
-    return unAuthRequest.post('api/v1/users/register', payload);
+    return unAuthRequest.post('api/v1/users/signup', payload);
   },
   logout: () => {
     return unAuthRequest.patch('/api/v1/users/logout');
@@ -20,7 +20,7 @@ const userAPI = {
   reissueToken: (payload: UserReissueTokenRequest) => {
     return authRequest.post(`api/v1/users/token/reissue`, payload);
   },
-  getInformation: (userId: number) => {
+  getUserInfo: (userId: number) => {
     return unAuthRequest.get(`/api/v1/users/${userId}/info`);
   },
   getMyReview: (userId: number, page: number, size: number) => {

--- a/components/atoms/LinkText/index.tsx
+++ b/components/atoms/LinkText/index.tsx
@@ -5,14 +5,14 @@ import { CSSProperties } from 'react';
 interface LinkTextProps {
   href: string;
   text: string;
-  textStyle?: CSSProperties;
+  style?: CSSProperties;
   isCurrentPage?: boolean;
 }
 
-const LinkText = ({ href, text, textStyle, isCurrentPage }: LinkTextProps) => {
+const LinkText = ({ href, text, style, isCurrentPage }: LinkTextProps) => {
   return (
     <Link href={href} passHref>
-      <StyledA style={textStyle} isCurrentPage={isCurrentPage}>
+      <StyledA style={style} isCurrentPage={isCurrentPage}>
         {text}
       </StyledA>
     </Link>
@@ -22,7 +22,7 @@ const LinkText = ({ href, text, textStyle, isCurrentPage }: LinkTextProps) => {
 const StyledA = styled.a<{
   isCurrentPage?: boolean;
 }>`
-  font-size: 2.6rem;
+  font-size: 2.4rem;
   white-space: nowrap;
 
   ${({ isCurrentPage }) =>
@@ -30,7 +30,7 @@ const StyledA = styled.a<{
     ` 
     color: #242f9b;
     font-weight: 500;
-    border-bottom: 4px solid #242f9b;
+    border-bottom: 3px solid #242f9b;
   `}
 `;
 

--- a/components/molecule/ReviewCard/index.tsx
+++ b/components/molecule/ReviewCard/index.tsx
@@ -49,11 +49,11 @@ const ReviewCard = ({
             ) : null}
           </S.PhotoWrapper>
           <S.UserInfoContainer>
-            <Link href={`/user/${userId}`}>
+            <Link href={`/users/${userId}`}>
               <S.UserInfoAvatar src={'https://joeschmoe.io/api/v1/random'} size={60} />
             </Link>
             <S.UserInfoTextContainer>
-              <Link href={`/user/${userId}`}>
+              <Link href={`/users/${userId}`}>
                 <S.UserInfoName>{nickname}</S.UserInfoName>
               </Link>
               <S.UserInfoDate>{displayDate(createdAt)}</S.UserInfoDate>

--- a/components/molecule/SideNavigation/index.tsx
+++ b/components/molecule/SideNavigation/index.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 import { Button } from 'antd';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useRecoilValue } from 'recoil';
+import { userAtom } from 'states';
 
 interface SideNavigationProps {
   paths: Array<{
@@ -11,7 +13,18 @@ interface SideNavigationProps {
 }
 
 const SideNavigation = ({ paths }: SideNavigationProps) => {
-  const { asPath } = useRouter();
+  // TODO: beforeRender라는 속성 추가. 콜백함수를 받아서 실행할 것
+  const userId = useRecoilValue(userAtom);
+  const {
+    query: { id },
+    asPath,
+  } = useRouter();
+
+  const isNotMyPage = String(userId) !== id;
+  if (isNotMyPage) {
+    return null;
+  }
+
   return (
     <Navigation>
       {paths.map(({ href, pageName }, i) => (

--- a/components/organism/Header/index.tsx
+++ b/components/organism/Header/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import Logo from 'components/atoms/Logo';
-import { Input } from 'antd';
+import { Input, message } from 'antd';
 import LinkText from 'components/atoms/LinkText';
 import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
@@ -9,6 +9,19 @@ import { userAtom } from 'states';
 const Header = () => {
   const { pathname } = useRouter();
   const userId = useRecoilValue(userAtom);
+  const router = useRouter();
+
+  const handleSearchExhibition = (value: string) => {
+    const isEmpty = !/\S/.test(value);
+    if (isEmpty || value.length < 2) {
+      message.warning('두 글자 이상 입력해주세요.');
+      return;
+    }
+    router.push({
+      pathname: '/search-result',
+      query: { exhibition: value },
+    });
+  };
 
   return (
     <StyledHeader>
@@ -42,7 +55,11 @@ const Header = () => {
           />
           <LinkText href="/community" text="커뮤니티" isCurrentPage={pathname === '/community'} />
         </Navigation>
-        <SearchBar placeholder="전시회 제목을 검색해주세요." allowClear />
+        <SearchBar
+          placeholder="전시회 제목을 검색해주세요."
+          allowClear
+          onSearch={handleSearchExhibition}
+        />
       </Container>
     </StyledHeader>
   );

--- a/components/organism/Header/index.tsx
+++ b/components/organism/Header/index.tsx
@@ -3,17 +3,29 @@ import Logo from 'components/atoms/Logo';
 import { Input } from 'antd';
 import LinkText from 'components/atoms/LinkText';
 import { useRouter } from 'next/router';
+import { useRecoilValue } from 'recoil';
+import { userAtom } from 'states';
 
 const Header = () => {
   const { pathname } = useRouter();
+  const userId = useRecoilValue(userAtom);
 
   return (
     <StyledHeader>
       <Container>
         <Logo width={252} height={92} />
         <Utility>
-          <LinkText href="/signin" text="로그인" />
-          <LinkText href="/signup" text="회원가입" />
+          {userId ? (
+            <>
+              <LinkText href={`/users/${userId}`} text="마이페이지" />
+              <LogoutButton>로그아웃</LogoutButton>
+            </>
+          ) : (
+            <>
+              <LinkText href="/signin" text="로그인" />
+              <LinkText href="/signup" text="회원가입" />
+            </>
+          )}
         </Utility>
       </Container>
       <Container>
@@ -21,7 +33,7 @@ const Header = () => {
           <LinkText
             href="/exhibitions/custom"
             text="맞춤 전시회"
-            isCurrentPage={pathname === '/search-result'}
+            isCurrentPage={pathname === '/exhibitions/custom'}
           />
           <LinkText
             href="/reviews/create"
@@ -77,8 +89,9 @@ const Navigation = styled.nav`
 
   & > a {
     margin-right: 80px;
-    padding-bottom: 20px;
+    padding-bottom: 14px;
     margin-bottom: -3px;
+    border-bottom: 3px solid transparent;
 
     &:last-of-type {
       margin-right: 0;
@@ -86,7 +99,7 @@ const Navigation = styled.nav`
 
     &:hover {
       font-weight: 500;
-      border-bottom: 4px solid ${({ theme }) => theme.color.blue.main};
+      border-bottom: 3px solid ${({ theme }) => theme.color.blue.main};
     }
 
     @media (max-width: 767px) {
@@ -100,53 +113,21 @@ const Navigation = styled.nav`
 `;
 
 const SearchBar = styled(Input.Search)`
-  // TODO: 스타일 초기화 - 재사용
-  * {
-    border: 0;
-    outline: none;
-    background: none;
-
-    &:hover,
-    &:active,
-    &:focus,
-    &:focus-within {
-      border: 0;
-      outline: none;
-      box-shadow: none;
-      background: none;
-      --antd-wave-shadow-color: none;
-    }
-  }
-
   width: 400px;
-  margin-bottom: 20px;
-  border: 2px solid ${({ theme }) => theme.color.blue.main};
-  border-radius: 18px;
-  overflow: hidden;
+  margin-bottom: 14px;
 
-  .ant-input-affix-wrapper {
-    padding: 8px 16px;
-  }
-
-  .ant-input {
-    font-size: 1.8rem;
-  }
-
-  .ant-input-clear-icon {
-    font-size: 1.8rem;
-  }
-
-  .ant-input-search-button {
-    margin-right: 10px;
-  }
-
-  .anticon-search {
-    font-size: 2.4rem;
+  .ant-btn {
+    height: 35px;
   }
 
   @media (max-width: 767px) {
     display: none;
   }
+`;
+
+const LogoutButton = styled.button`
+  font-size: 2.4rem;
+  white-space: nowrap;
 `;
 
 export default Header;

--- a/constants/imageUrl.ts
+++ b/constants/imageUrl.ts
@@ -1,4 +1,6 @@
 const imageUrl = {
+  USER_DEFAULT:
+    'https://devcourse-backfro-s3.s3.ap-northeast-2.amazonaws.com/profileImage/default/anonymous-user.jpg',
   EXHIBITION_DEFAULT:
     'https://raw.githubusercontent.com/gitul0515/gitul0515.github.io/main/_posts/image/poster-default-image.png',
 };

--- a/pages/users/[id]/edit-password/index.tsx
+++ b/pages/users/[id]/edit-password/index.tsx
@@ -1,8 +1,12 @@
 import styled from '@emotion/styled';
 import { Form, Input, Button } from 'antd';
 import { SideNavigation } from 'components/molecule';
+import { useRecoilValue } from 'recoil';
+import { userAtom } from 'states';
 
 const UserEditPasswordPage = () => {
+  const userId = useRecoilValue(userAtom);
+
   return (
     <PageContainer>
       <Title>비밀번호 변경</Title>
@@ -22,15 +26,15 @@ const UserEditPasswordPage = () => {
       <SideNavigation
         paths={[
           {
-            href: '/users/1', // TODO: `/users/${userId}`로 수정
+            href: `/users/${userId}`,
             pageName: '사용자 정보',
           },
           {
-            href: '/users/1/edit',
+            href: `/users/${userId}/edit`,
             pageName: '프로필 수정',
           },
           {
-            href: '/users/1/edit-password',
+            href: `/users/${userId}/edit-password`,
             pageName: '비밀번호 변경',
           },
         ]}
@@ -41,7 +45,7 @@ const UserEditPasswordPage = () => {
 
 const PageContainer = styled.div`
   position: relative;
-  max-width: 1000px;
+  max-width: 1100px;
   margin: 0 auto;
   padding-left: 200px;
 `;

--- a/pages/users/[id]/edit/index.tsx
+++ b/pages/users/[id]/edit/index.tsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 import { Button, Form, Input, Image } from 'antd';
 import { useState, useRef, ChangeEvent } from 'react';
 import { SideNavigation } from 'components/molecule';
+import { useRecoilValue } from 'recoil';
+import { userAtom } from 'states';
 
 const UserEditPage = () => {
   const [image, setImage] = useState<string>(
@@ -9,6 +11,7 @@ const UserEditPage = () => {
   );
   const [file, setFile] = useState<FileList>(); // TODO: 업로드한 파일 저장 미구현 상태. 추후 구현 필요
   const fileInput = useRef<HTMLInputElement>(null);
+  const userId = useRecoilValue(userAtom);
 
   const handleImageClick = () => {
     if (fileInput.current) {
@@ -52,15 +55,15 @@ const UserEditPage = () => {
       <SideNavigation
         paths={[
           {
-            href: '/users/1', // TODO: `/users/${userId}`로 수정
+            href: `/users/${userId}`,
             pageName: '사용자 정보',
           },
           {
-            href: '/users/1/edit',
+            href: `/users/${userId}/edit`,
             pageName: '프로필 수정',
           },
           {
-            href: '/users/1/edit-password',
+            href: `/users/${userId}/edit-password`,
             pageName: '비밀번호 변경',
           },
         ]}
@@ -71,7 +74,7 @@ const UserEditPage = () => {
 
 const PageContainer = styled.div`
   position: relative;
-  max-width: 1000px;
+  max-width: 1100px;
   margin: 0 auto;
   padding-left: 200px;
 `;

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -1,44 +1,28 @@
 import styled from '@emotion/styled';
-import { Tabs, Image } from 'antd';
+import { Tabs, Image, Spin } from 'antd';
 import { ReviewCard, ExhibitionCard, SideNavigation } from 'components/molecule';
 import { userAPI } from 'apis';
-import { GetServerSideProps, GetStaticProps } from 'next';
-import { UserInfoResponse } from 'types/apis/user';
-import { useEffect, useState } from 'react';
-import { ExhibitionProps } from 'types/model';
-import imageUrl from 'constants/imageUrl';
+import { GetServerSideProps } from 'next';
+import { UserInfoResponse, UserReviewResponse } from 'types/apis/user';
+import { useState } from 'react';
+import { ReviewCardProps, ExhibitionProps } from 'types/model';
 
 interface UserPageProps {
-  userInfo: {
-    nickname: string;
-    userId: number;
-    profileImage: string;
-    email: string;
-    reviewCount: number;
-    reviewLikeCount: number;
-    exhibitionLikeCount: number;
-    commentCount: number;
-  };
-  userExhibitions: {
-    exhibitionId: number;
-    name: string;
-    thumbnail: string;
-    startDate: string;
-    endDate: string;
-    likeCount: number;
-    reviewCount: number;
-    isLiked: boolean;
-  }[];
+  userInfoResponse: UserInfoResponse;
+  userReviewResponse: UserReviewResponse;
 }
 
-const UserPage = ({ userInfo, userExhibitions }: UserPageProps) => {
-  const [myReviews, setMyReviews] = useState();
-  const [likeReviews, setLikeReviews] = useState();
+const UserPage = ({ userInfoResponse, userReviewResponse }: UserPageProps) => {
+  const userInfo = userInfoResponse.data;
+  const userReviews = userReviewResponse.data?.content;
+
+  const [myReviews, setMyReviews] = useState<ReviewCardProps[] | undefined>(userReviews);
+  const [likeReviews, setLikeReviews] = useState<ReviewCardProps[]>();
+  const [likeExhibitions, setLikeExhibitions] = useState<Required<ExhibitionProps>[]>();
 
   const handleTabClick = (key: string) => {
     switch (key) {
       case 'myReview': {
-        fetchMyReviews();
         return;
       }
       case 'likeReview': {
@@ -46,71 +30,110 @@ const UserPage = ({ userInfo, userExhibitions }: UserPageProps) => {
         return;
       }
       case 'likeExhibition': {
+        fetchLikeExhibitions();
         return;
       }
       default:
-        console.error('유효하지 않은 key입니다.');
+        console.error('Invalid key');
     }
   };
 
-  const fetchMyReviews = async () => {
-    const result = await userAPI.getMyReview(userInfo.userId, 0, 10).then((res) => res.data);
-    console.log(result);
-  };
-
   const fetchLikeReviews = async () => {
-    const result = await userAPI.getLikeReview(userInfo.userId, 0, 10).then((res) => res.data);
-    console.log(result);
+    if (userInfo && !likeReviews) {
+      const { content } = await userAPI
+        .getLikeReview(userInfo.userId, 0, 10)
+        .then((res) => res.data.data);
+      setLikeReviews(content);
+    }
   };
 
-  return userInfo && userExhibitions ? (
+  const fetchLikeExhibitions = async () => {
+    if (userInfo && !likeExhibitions) {
+      const { content } = await userAPI
+        .getLikeExhibition(userInfo.userId, 0, 10)
+        .then((res) => res.data.data);
+      setLikeExhibitions(content);
+    }
+  };
+
+  return userInfo && userReviews ? (
     <PageContainer>
       <ProfileContainer>
-        <ProfileImage src={userInfo.profileImage} alt="프로필 이미지" preview={false} />
+        <ProfileImage src={userInfo.profileImage} alt="프로필 이미지" />
         <UserName>{userInfo.nickname}</UserName>
         <UserEmail>{userInfo.email}</UserEmail>
       </ProfileContainer>
       <TabCardContainer type="card" tabPosition="top" centered onTabClick={handleTabClick}>
-        <Tab tab={`작성한 후기 (${userInfo.reviewCount})`} key="myReview"></Tab>
+        <Tab tab={`작성한 후기 (${userInfo.reviewCount})`} key="myReview">
+          <ReviewContainer>
+            {myReviews?.map((review) => (
+              <ReviewCard
+                key={review.reviewId}
+                reviewId={review.reviewId}
+                title={review.title}
+                content={review.content}
+                thumbnail={review.exhibition.thumbnail}
+                createdAt={review.createdAt}
+                likeCount={review.likeCount}
+                commentCount={review.commentCount}
+                photo={review.photos[0]?.path}
+                userId={review.user.userId}
+                nickname={review.user.nickname}
+                profileImage={review.user.profileImage}
+              />
+            ))}
+          </ReviewContainer>
+        </Tab>
         <Tab tab={`좋아하는 후기 (${userInfo.reviewLikeCount})`} key="likeReview">
           <ReviewContainer>
-            <ReviewCard
-              reviewId={reviewDummy.reviewId}
-              thumbnail={reviewDummy.exhibition.thumbnail}
-              title={reviewDummy.title}
-              content={reviewDummy.content}
-              createdAt={reviewDummy.createdAt}
-              likeCount={reviewDummy.likeCount}
-              commentCount={reviewDummy.commentCount}
-              photo={reviewDummy.photos[0]}
-              userId={reviewDummy.user.userId}
-              nickname={reviewDummy.user.nickname}
-              profileImage={reviewDummy.user.profileImage}
-            />
+            {likeReviews ? (
+              likeReviews.map((review) => (
+                <ReviewCard
+                  key={review.reviewId}
+                  reviewId={review.reviewId}
+                  title={review.title}
+                  content={review.content}
+                  thumbnail={review.exhibition.thumbnail}
+                  createdAt={review.createdAt}
+                  likeCount={review.likeCount}
+                  commentCount={review.commentCount}
+                  photo={review.photos[0]?.path}
+                  userId={review.user.userId}
+                  nickname={review.user.nickname}
+                  profileImage={review.user.profileImage}
+                />
+              ))
+            ) : (
+              <Spinner size="large" />
+            )}
           </ReviewContainer>
         </Tab>
         <Tab tab={`좋아하는 전시회 (${userInfo.exhibitionLikeCount})`} key="likeExhibition">
           <ExhibitionContainer>
-            {userExhibitions.map((exhibition) => (
-              <ExhibitionCard
-                key={exhibition.exhibitionId}
-                exhibitionId={exhibition.exhibitionId}
-                name={exhibition.name}
-                thumbnail={exhibition.thumbnail}
-                startDate={exhibition.startDate}
-                endDate={exhibition.endDate}
-                likeCount={exhibition.likeCount}
-                reviewCount={exhibition.reviewCount}
-                isLiked={exhibition.isLiked}
-              />
-            ))}
+            {likeExhibitions ? (
+              likeExhibitions.map((exhibition) => (
+                <ExhibitionCard
+                  key={exhibition.exhibitionId}
+                  exhibitionId={exhibition.exhibitionId}
+                  name={exhibition.name}
+                  thumbnail={exhibition.thumbnail}
+                  startDate={exhibition.startDate}
+                  endDate={exhibition.endDate}
+                  likeCount={exhibition.likeCount}
+                  reviewCount={exhibition.reviewCount}
+                  isLiked={exhibition.isLiked}
+                />
+              ))
+            ) : (
+              <Spinner size="large" />
+            )}
           </ExhibitionContainer>
         </Tab>
       </TabCardContainer>
       <SideNavigation
         paths={[
           {
-            href: `/users/${userInfo.userId}`, // TODO: `/users/${userId}`로 수정
+            href: `/users/${userInfo.userId}`,
             pageName: '사용자 정보',
           },
           {
@@ -125,36 +148,39 @@ const UserPage = ({ userInfo, userExhibitions }: UserPageProps) => {
       />
     </PageContainer>
   ) : (
-    '로딩 중입니다.'
+    <Spinner size="large" />
   );
 };
 
+// TODO: 추후 getStaticProps로 변경 예정 (getStaticPaths도 추가)
 export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   if (params) {
-    const userInfo = await userAPI.getInformation(Number(params.id)).then((res) => res.data.data);
+    const userInfoResponse = await userAPI
+      .getInformation(Number(params.id))
+      .then((res) => res.data);
 
-    const userExhibitions = await userAPI
-      .getLikeExhibition(Number(params.id), 0, 10)
-      .then((res) => res.data.data.content);
+    const userReviewResponse = await userAPI
+      .getMyReview(Number(params.id), 0, 10)
+      .then((res) => res.data);
 
     return {
       props: {
-        userInfo,
-        userExhibitions,
+        userInfoResponse,
+        userReviewResponse,
       },
     };
   }
   return {
     props: {
-      userInfo: {},
-      userExhibitions: {},
+      userInfoResponse: {},
+      userReviewResponse: {},
     },
   };
 };
 
 const PageContainer = styled.div`
   position: relative;
-  max-width: 1000px;
+  max-width: 1100px;
   margin: 0 auto;
   text-align: center;
 `;
@@ -205,7 +231,9 @@ const ReviewContainer = styled.div`
 const ExhibitionContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(4, 1fr);
+  justify-content: center;
   justify-items: center;
+  gap: 10px;
   padding-bottom: 30px;
 
   @media screen and (max-width: ${({ theme }) => theme.breakPoint.tablet}) {
@@ -217,35 +245,8 @@ const ExhibitionContainer = styled.div`
   }
 `;
 
-const reviewDummy = {
-  reviewId: 43,
-  user: {
-    userId: 11,
-    profileImage: 'https~',
-    nickname: 'Emily',
-  },
-  exhibition: {
-    exhibitionId: 24,
-    name: '전시회 이름',
-    startDate: '2022-10-11',
-    thumbnail: 'https~~',
-  },
-  title: '번아웃증후군 전시회 다녀옴~',
-  content:
-    '오늘 핸드아트코리아 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 핸드아트코리아 전시회를 다녀왔다. 정말 재밌었다~~',
-  createdAt: '2022-03-22T22:33:11',
-  updatedAt: '2022-03-23T13:03:51',
-  isEdited: true,
-  isLiked: false,
-  isPublic: true,
-  likeCount: 32,
-  commentCount: 2,
-  photos: ['https~', 'https~'],
-};
-
-const exhibitionCardStyle = {
-  width: '240px',
-  height: '350px',
-};
+const Spinner = styled(Spin)`
+  margin-bottom: 400px;
+`;
 
 export default UserPage;

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -1,21 +1,59 @@
 import styled from '@emotion/styled';
 import { Tabs, Image } from 'antd';
 import { ReviewCard, ExhibitionCard, SideNavigation } from 'components/molecule';
+import { userAPI } from 'apis';
+import { GetStaticProps } from 'next';
+import { UserInfoResponse } from 'types/apis/user';
+import { useEffect, useState } from 'react';
+import { ExhibitionProps } from 'types/model';
 
-const UserPage = () => {
-  return (
+interface UserPageProps {
+  userInfo: {
+    nickname: string;
+    userId: number;
+    profileImage: string;
+    email: string;
+    reviewCount: number;
+    reviewLikeCount: number;
+    exhibitionLikeCount: number;
+    commentCount: number;
+  };
+  userExhibitions: {
+    exhibitionId: number;
+    name: string;
+    thumbnail: string;
+    startDate: string;
+    endDate: string;
+    likeCount: number;
+    reviewCount: number;
+    isLiked: boolean;
+  }[];
+}
+
+const UserPage = ({ userInfo, userExhibitions }: UserPageProps) => {
+  const [likeExhibitions, setLikeExhibitions] = useState(userExhibitions);
+
+  console.log(likeExhibitions);
+
+  useEffect(() => {
+    setLikeExhibitions(userExhibitions);
+    console.log(likeExhibitions);
+  }, [userExhibitions]);
+
+  const handleTabClick = (key: string) => {
+    console.log(key);
+  };
+
+  return userInfo && userExhibitions ? (
     <PageContainer>
       <ProfileContainer>
-        <ProfileImage
-          src="https://zos.alipayobjects.com/rmsportal/jkjgkEfvpUPVyRjUImniVslZfWPnJuuZ.png"
-          alt="profile image"
-          preview={false}
-        />
-        <UserName>비긴어게인</UserName>
-        <UserEmail>gitul0515@gmail.com</UserEmail>
+        <ProfileImage src={userInfo.profileImage} alt="프로필 이미지" preview={false} />
+        <UserName>{userInfo.nickname}</UserName>
+        <UserEmail>{userInfo.email}</UserEmail>
       </ProfileContainer>
-      <TabCardContainer type="card" tabPosition="top" centered>
-        <Tab tab="작성한 글 (12)" key={1}>
+      <TabCardContainer type="card" tabPosition="top" centered onTabClick={handleTabClick}>
+        <Tab tab={`작성한 후기 (${userInfo.reviewCount})`} key="myReview"></Tab>
+        <Tab tab={`좋아하는 후기 (${userInfo.reviewLikeCount})`} key="likeReview">
           <ReviewContainer>
             <ReviewCard
               reviewId={reviewDummy.reviewId}
@@ -30,156 +68,24 @@ const UserPage = () => {
               nickname={reviewDummy.user.nickname}
               profileImage={reviewDummy.user.profileImage}
             />
-            <ReviewCard
-              reviewId={reviewDummy.reviewId}
-              thumbnail={reviewDummy.exhibition.thumbnail}
-              title={reviewDummy.title}
-              content={reviewDummy.content}
-              createdAt={reviewDummy.createdAt}
-              likeCount={reviewDummy.likeCount}
-              commentCount={reviewDummy.commentCount}
-              photo={reviewDummy.photos[0]}
-              userId={reviewDummy.user.userId}
-              nickname={reviewDummy.user.nickname}
-              profileImage={reviewDummy.user.profileImage}
-            />
-            <ReviewCard
-              reviewId={reviewDummy.reviewId}
-              thumbnail={reviewDummy.exhibition.thumbnail}
-              title={reviewDummy.title}
-              content="오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~"
-              createdAt={reviewDummy.createdAt}
-              likeCount={reviewDummy.likeCount}
-              commentCount={reviewDummy.commentCount}
-              photo={reviewDummy.photos[0]}
-              userId={reviewDummy.user.userId}
-              nickname={reviewDummy.user.nickname}
-              profileImage={reviewDummy.user.profileImage}
-            />
-            <ReviewCard
-              reviewId={reviewDummy.reviewId}
-              thumbnail={reviewDummy.exhibition.thumbnail}
-              title={reviewDummy.title}
-              content="오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ "
-              createdAt={reviewDummy.createdAt}
-              likeCount={reviewDummy.likeCount}
-              commentCount={reviewDummy.commentCount}
-              photo={reviewDummy.photos[0]}
-              userId={reviewDummy.user.userId}
-              nickname={reviewDummy.user.nickname}
-              profileImage={reviewDummy.user.profileImage}
-            />
-            <ReviewCard
-              reviewId={reviewDummy.reviewId}
-              thumbnail={reviewDummy.exhibition.thumbnail}
-              title={reviewDummy.title}
-              content="오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~ 오늘 번아웃증후군 전시회를 다녀왔다. 정말 재밌었다~~"
-              createdAt={reviewDummy.createdAt}
-              likeCount={reviewDummy.likeCount}
-              commentCount={reviewDummy.commentCount}
-              photo={reviewDummy.photos[0]}
-              userId={reviewDummy.user.userId}
-              nickname={reviewDummy.user.nickname}
-              profileImage={reviewDummy.user.profileImage}
-            />
           </ReviewContainer>
         </Tab>
-        <Tab tab="좋아하는 전시회 (6)" key={2}>
+        <Tab tab={`좋아하는 전시회 (${userInfo.exhibitionLikeCount})`} key="likeExhibition">
           <ExhibitionContainer>
-            <ExhibitionCard
-              exhibitionId={exhibitionDummy.exhibitionId}
-              name={exhibitionDummy.name}
-              thumbnail={exhibitionDummy.thumbnail}
-              startDate={exhibitionDummy.startDate}
-              endDate={exhibitionDummy.endDate}
-              likeCount={exhibitionDummy.likeCount}
-              reviewCount={exhibitionDummy.reviewCount}
-              isLiked={exhibitionDummy.isLiked}
-            />
-            <ExhibitionCard
-              exhibitionId={exhibitionDummy.exhibitionId}
-              name={exhibitionDummy.name}
-              thumbnail={exhibitionDummy.thumbnail}
-              startDate={exhibitionDummy.startDate}
-              endDate={exhibitionDummy.endDate}
-              likeCount={exhibitionDummy.likeCount}
-              reviewCount={exhibitionDummy.reviewCount}
-              isLiked={exhibitionDummy.isLiked}
-            />
-            <ExhibitionCard
-              exhibitionId={exhibitionDummy.exhibitionId}
-              name={exhibitionDummy.name}
-              thumbnail={exhibitionDummy.thumbnail}
-              startDate={exhibitionDummy.startDate}
-              endDate={exhibitionDummy.endDate}
-              likeCount={exhibitionDummy.likeCount}
-              reviewCount={exhibitionDummy.reviewCount}
-              isLiked={exhibitionDummy.isLiked}
-            />
-            <ExhibitionCard
-              exhibitionId={exhibitionDummy.exhibitionId}
-              name={exhibitionDummy.name}
-              thumbnail={exhibitionDummy.thumbnail}
-              startDate={exhibitionDummy.startDate}
-              endDate={exhibitionDummy.endDate}
-              likeCount={exhibitionDummy.likeCount}
-              reviewCount={exhibitionDummy.reviewCount}
-              isLiked={exhibitionDummy.isLiked}
-            />
-            <ExhibitionCard
-              exhibitionId={exhibitionDummy.exhibitionId}
-              name={exhibitionDummy.name}
-              thumbnail={exhibitionDummy.thumbnail}
-              startDate={exhibitionDummy.startDate}
-              endDate={exhibitionDummy.endDate}
-              likeCount={exhibitionDummy.likeCount}
-              reviewCount={exhibitionDummy.reviewCount}
-              isLiked={exhibitionDummy.isLiked}
-            />
+            {userExhibitions.map((exhibition) => (
+              <ExhibitionCard
+                key={exhibition.exhibitionId}
+                exhibitionId={exhibition.exhibitionId}
+                name={exhibition.name}
+                thumbnail={exhibition.thumbnail}
+                startDate={exhibition.startDate}
+                endDate={exhibition.endDate}
+                likeCount={exhibition.likeCount}
+                reviewCount={exhibition.reviewCount}
+                isLiked={exhibition.isLiked}
+              />
+            ))}
           </ExhibitionContainer>
-        </Tab>
-        <Tab tab="좋아하는 후기 (17)" key={3}>
-          <ReviewContainer>
-            <ReviewCard
-              reviewId={reviewDummy.reviewId}
-              thumbnail={reviewDummy.exhibition.thumbnail}
-              title={reviewDummy.title}
-              content={reviewDummy.content}
-              createdAt={reviewDummy.createdAt}
-              likeCount={reviewDummy.likeCount}
-              commentCount={reviewDummy.commentCount}
-              photo={reviewDummy.photos[0]}
-              userId={reviewDummy.user.userId}
-              nickname={reviewDummy.user.nickname}
-              profileImage={reviewDummy.user.profileImage}
-            />
-            <ReviewCard
-              reviewId={reviewDummy.reviewId}
-              thumbnail={reviewDummy.exhibition.thumbnail}
-              title={reviewDummy.title}
-              content={reviewDummy.content}
-              createdAt={reviewDummy.createdAt}
-              likeCount={reviewDummy.likeCount}
-              commentCount={reviewDummy.commentCount}
-              photo={reviewDummy.photos[0]}
-              userId={reviewDummy.user.userId}
-              nickname={reviewDummy.user.nickname}
-              profileImage={reviewDummy.user.profileImage}
-            />
-            <ReviewCard
-              reviewId={reviewDummy.reviewId}
-              thumbnail={reviewDummy.exhibition.thumbnail}
-              title={reviewDummy.title}
-              content={reviewDummy.content}
-              createdAt={reviewDummy.createdAt}
-              likeCount={reviewDummy.likeCount}
-              commentCount={reviewDummy.commentCount}
-              photo={reviewDummy.photos[0]}
-              userId={reviewDummy.user.userId}
-              nickname={reviewDummy.user.nickname}
-              profileImage={reviewDummy.user.profileImage}
-            />
-          </ReviewContainer>
         </Tab>
       </TabCardContainer>
       <SideNavigation
@@ -199,8 +105,40 @@ const UserPage = () => {
         ]}
       />
     </PageContainer>
+  ) : (
+    '로딩 중입니다.'
   );
 };
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  if (params) {
+    const userInfo = await userAPI.getInformation(Number(params.id)).then((res) => res.data.data);
+
+    const userExhibitions = await userAPI
+      .getLikeExhibition(Number(params.id), 0, 10)
+      .then((res) => res.data.data.content);
+
+    return {
+      props: {
+        userInfo,
+        userExhibitions,
+      },
+    };
+  }
+  return {
+    props: {
+      userInfo: {},
+      userExhibitions: {},
+    },
+  };
+};
+
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: true,
+  };
+}
 
 const PageContainer = styled.div`
   position: relative;

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -2,10 +2,11 @@ import styled from '@emotion/styled';
 import { Tabs, Image } from 'antd';
 import { ReviewCard, ExhibitionCard, SideNavigation } from 'components/molecule';
 import { userAPI } from 'apis';
-import { GetStaticProps } from 'next';
+import { GetServerSideProps, GetStaticProps } from 'next';
 import { UserInfoResponse } from 'types/apis/user';
 import { useEffect, useState } from 'react';
 import { ExhibitionProps } from 'types/model';
+import imageUrl from 'constants/imageUrl';
 
 interface UserPageProps {
   userInfo: {
@@ -31,17 +32,35 @@ interface UserPageProps {
 }
 
 const UserPage = ({ userInfo, userExhibitions }: UserPageProps) => {
-  const [likeExhibitions, setLikeExhibitions] = useState(userExhibitions);
-
-  console.log(likeExhibitions);
-
-  useEffect(() => {
-    setLikeExhibitions(userExhibitions);
-    console.log(likeExhibitions);
-  }, [userExhibitions]);
+  const [myReviews, setMyReviews] = useState();
+  const [likeReviews, setLikeReviews] = useState();
 
   const handleTabClick = (key: string) => {
-    console.log(key);
+    switch (key) {
+      case 'myReview': {
+        fetchMyReviews();
+        return;
+      }
+      case 'likeReview': {
+        fetchLikeReviews();
+        return;
+      }
+      case 'likeExhibition': {
+        return;
+      }
+      default:
+        console.error('유효하지 않은 key입니다.');
+    }
+  };
+
+  const fetchMyReviews = async () => {
+    const result = await userAPI.getMyReview(userInfo.userId, 0, 10).then((res) => res.data);
+    console.log(result);
+  };
+
+  const fetchLikeReviews = async () => {
+    const result = await userAPI.getLikeReview(userInfo.userId, 0, 10).then((res) => res.data);
+    console.log(result);
   };
 
   return userInfo && userExhibitions ? (
@@ -91,15 +110,15 @@ const UserPage = ({ userInfo, userExhibitions }: UserPageProps) => {
       <SideNavigation
         paths={[
           {
-            href: '/users/1', // TODO: `/users/${userId}`로 수정
+            href: `/users/${userInfo.userId}`, // TODO: `/users/${userId}`로 수정
             pageName: '사용자 정보',
           },
           {
-            href: '/users/1/edit',
+            href: `/users/${userInfo.userId}/edit`,
             pageName: '프로필 수정',
           },
           {
-            href: '/users/1/edit-password',
+            href: `/users/${userInfo.userId}/edit-password`,
             pageName: '비밀번호 변경',
           },
         ]}
@@ -110,7 +129,7 @@ const UserPage = ({ userInfo, userExhibitions }: UserPageProps) => {
   );
 };
 
-export const getStaticProps: GetStaticProps = async ({ params }) => {
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   if (params) {
     const userInfo = await userAPI.getInformation(Number(params.id)).then((res) => res.data.data);
 
@@ -132,13 +151,6 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     },
   };
 };
-
-export async function getStaticPaths() {
-  return {
-    paths: [],
-    fallback: true,
-  };
-}
 
 const PageContainer = styled.div`
   position: relative;
@@ -229,17 +241,6 @@ const reviewDummy = {
   likeCount: 32,
   commentCount: 2,
   photos: ['https~', 'https~'],
-};
-
-const exhibitionDummy = {
-  exhibitionId: 1,
-  name: '번아웃증후군',
-  thumbnail: 'https://www.culture.go.kr/upload/rdf/22/07/show_2022071816261910020.jpg',
-  startDate: '2022-08-04',
-  endDate: '2022-08-10',
-  isLiked: false,
-  likeCount: 5,
-  reviewCount: 3,
 };
 
 const exhibitionCardStyle = {

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -155,9 +155,7 @@ const UserPage = ({ userInfoResponse, userReviewResponse }: UserPageProps) => {
 // TODO: 추후 getStaticProps로 변경 예정 (getStaticPaths도 추가)
 export const getServerSideProps: GetServerSideProps = async ({ params }) => {
   if (params) {
-    const userInfoResponse = await userAPI
-      .getInformation(Number(params.id))
-      .then((res) => res.data);
+    const userInfoResponse = await userAPI.getUserInfo(Number(params.id)).then((res) => res.data); // 추후 then을 await으로 변경
 
     const userReviewResponse = await userAPI
       .getMyReview(Number(params.id), 0, 10)

--- a/types/apis/user/index.ts
+++ b/types/apis/user/index.ts
@@ -1,4 +1,4 @@
-import { ExhibitionProps, ReviewProps } from 'types/model';
+import { ExhibitionProps, ReviewCardProps } from 'types/model';
 import { BaseResponse } from '../base';
 
 export interface UserLocalLoginRequest {
@@ -26,9 +26,9 @@ export interface UserReissueTokenRequest {
   refreshToken: string; // 만료되지 않은 refreshToken
 }
 
-export interface UserInfoReviewLikeResponse extends BaseResponse {
+export interface UserReviewResponse extends BaseResponse {
   data?: {
-    content: ReviewProps[];
+    content: ReviewCardProps[];
   };
 }
 

--- a/types/apis/user/index.ts
+++ b/types/apis/user/index.ts
@@ -53,9 +53,9 @@ export interface UserInfoResponse extends BaseResponse {
     profileImage: string;
     email: string;
     reviewCount: number;
-    likeCount: number;
+    reviewLikeCount: number;
+    exhibitionLikeCount: number;
     commentCount: number;
-    reviews: ReviewProps[];
   };
 }
 

--- a/types/model.ts
+++ b/types/model.ts
@@ -29,6 +29,23 @@ export interface ReviewProps {
   isLiked: boolean;
 }
 
+export interface ReviewCardProps {
+  reviewId: number;
+  user: UserProps;
+  exhibition: ExhibitionProps;
+  date: string;
+  title: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+  isEdited: boolean;
+  isLiked: boolean;
+  isPublic: boolean;
+  likeCount: number;
+  commentCount: number;
+  photos: PhotoProps[];
+}
+
 // TODO: 명세서 올라오면 수정하기
 export interface CommentProps {
   commentId: number;


### PR DESCRIPTION
# 작업 내용 (TODO)

유저 페이지에 API를 연동하여 기능을 구현했습니다. 
또한, 로그인 여부에 따라 헤더가 바뀌도록 구현했습니다. (유저 페이지가 보이도록)

- [x] 유저의 정보 조회 기능
- [x] 유저가 작성한 후기, 좋아요 누른 후기, 좋아요 누른 전시회 조회 기능
- [x] 로그인 여부에 따라 헤더의 유틸리티 메뉴 변화



# 사진 

https://user-images.githubusercontent.com/80658269/184224417-537a5ad6-264c-4705-85d5-57358adf81c8.mp4

페이지네이션은 아직 구현하지 않았습니다. 
현재는 최대 10개만 받아와서 보여주는 상태입니다. (추후 작업 예정)

로그인 전 

![image](https://user-images.githubusercontent.com/80658269/184224546-1757712e-45c5-47ff-a5af-9a2abad7e0d2.png)

로그인 후 

![image](https://user-images.githubusercontent.com/80658269/184224679-e9fba1cc-6c20-47e5-a29d-854b452f1e79.png)

마이페이지를 클릭하면 자신(로그인한 유저)의 유저페이지로 이동합니다. 
그 외, Card나 Comment 컴포넌트 등에서 유저의 아바타를 클릭 시, 
해당 유저의 유저페이지로 이동합니다. 

자신(로그인한 유저)의 유저페이지에서는 아래의 사이드바가 보이고, 
다른 유저인 경우 안 보인다는 차이가 있습니다. 

![image](https://user-images.githubusercontent.com/80658269/184225197-795606b0-6ece-43ef-9370-ae6a78586f97.png)

헤더 검색 기능 추가 @Hyevvy 

![image](https://user-images.githubusercontent.com/80658269/184308808-6e81f5f4-287a-4120-a17f-32a25c78e749.png)

검색 시 search-result 페이지로 이동합니다. 

![image](https://user-images.githubusercontent.com/80658269/184309031-b0611032-deeb-47a2-8cb1-45949a2afa64.png)

![image](https://user-images.githubusercontent.com/80658269/184309071-4f8c04e1-5395-49c3-83a2-ed13b4542507.png)

# 논의하고 싶은 부분

close #145 
