### PR TITLE
feat: 프로필 사진, 닉네임 수정 기능 구현

### DIFF
--- a/apis/user/index.ts
+++ b/apis/user/index.ts
@@ -1,5 +1,10 @@
 import { unAuthRequest, authRequest } from 'apis/common';
-import { UserLocalLoginRequest, UserReissueTokenRequest, UserSignupRequest } from 'types/apis/user';
+import {
+  UserLocalLoginRequest,
+  UserReissueTokenRequest,
+  UserSignupRequest,
+  UserChangePasswordRequest,
+} from 'types/apis/user';
 
 const userAPI = {
   localLogin: (payload: UserLocalLoginRequest) => {
@@ -36,6 +41,16 @@ const userAPI = {
     return unAuthRequest.get(
       `/api/v1/users/${userId}/info/exhibitions/like?page=${page}&size=${size}`,
     );
+  },
+  changeMyInfo: (formData: FormData) => {
+    return authRequest.patch(`/api/v1/users/me/info`, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+  },
+  changePassword: (payload: UserChangePasswordRequest) => {
+    return authRequest.patch(`/api/v1/users/me/password`, payload);
   },
 };
 

--- a/components/molecule/SideNavigation/index.tsx
+++ b/components/molecule/SideNavigation/index.tsx
@@ -7,8 +7,12 @@ import { userAtom } from 'states';
 
 interface SideNavigationProps {
   paths: Array<{
-    href: string;
+    pathName: string;
     pageName: string;
+    query?: {
+      nickname: string;
+      profileImage: string;
+    };
   }>;
 }
 
@@ -27,10 +31,20 @@ const SideNavigation = ({ paths }: SideNavigationProps) => {
 
   return (
     <Navigation>
-      {paths.map(({ href, pageName }, i) => (
-        <Link href={href} key={i}>
+      {paths.map(({ pathName, pageName, query }, i) => (
+        <Link
+          href={{
+            pathname: pathName,
+            query: {
+              nickname: query?.nickname,
+              profileImage: query?.profileImage,
+            },
+          }}
+          as={pathName}
+          key={i}
+        >
           <a>
-            <NavigationButton type={asPath === href ? 'primary' : 'default'} size="large">
+            <NavigationButton type={asPath === pathName ? 'primary' : 'default'} size="large">
               {pageName}
             </NavigationButton>
           </a>

--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -2,3 +2,4 @@ export { default as useInfiniteScroll } from './useInfiniteScroll';
 export { default as useClickAway } from './useClickAway';
 export { default as useAxios } from './useAxios';
 export { default as useUserAuthActions } from './useUserAuthActions';
+export { default as useInput } from './useInput';

--- a/hooks/useInput/index.ts
+++ b/hooks/useInput/index.ts
@@ -1,0 +1,15 @@
+import { useState } from 'react';
+import { ChangeEvent } from 'react';
+
+const useInput = (defaultValue: string) => {
+  const [value, setValue] = useState(defaultValue);
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target;
+    setValue(value);
+  };
+
+  return [value, onChange];
+};
+
+export default useInput;

--- a/pages/reviews/create/index.tsx
+++ b/pages/reviews/create/index.tsx
@@ -71,8 +71,8 @@ const ReviewCreatePage = () => {
 
     // TODO: 제출 전, validation 검사 추가
 
-    let formData = objectToFormData(submitData.current);
-    formData = filesToFormData(files, formData);
+    let formData = objectToFormData('data', submitData.current);
+    formData = filesToFormData('files', files, formData);
 
     try {
       await reviewAPI.createReview(formData);

--- a/pages/users/[id]/edit-password/index.tsx
+++ b/pages/users/[id]/edit-password/index.tsx
@@ -14,17 +14,17 @@ const UserEditPasswordPage = () => {
   return (
     <PageContainer>
       <Title>비밀번호 변경</Title>
-      <PasswordEditForm layout="vertical" form={form}>
+      <PasswordEditForm layout="vertical">
         <FormItem label="현재 비밀번호" name="oldPassword">
-          <Input type="password" onChange={(e) => handleChange('oldPassword', e.target.value)} />
+          <Input type="password" />
         </FormItem>
         <FormItem label="비밀번호" name="newPassword">
-          <Input type="password" onChange={(e) => handleChange('newPassword', e.target.value)} />
+          <Input type="password" />
         </FormItem>
         <FormItem label="비밀번호 확인" name="passwordCheck">
           <Input type="password" />
         </FormItem>
-        <SubmitButton type="primary" htmlType="submit" onClick={handleSubmit}>
+        <SubmitButton type="primary" htmlType="submit">
           변경
         </SubmitButton>
       </PasswordEditForm>

--- a/pages/users/[id]/edit-password/index.tsx
+++ b/pages/users/[id]/edit-password/index.tsx
@@ -1,8 +1,12 @@
 import styled from '@emotion/styled';
 import { Form, Input, Button } from 'antd';
 import { SideNavigation } from 'components/molecule';
+import { useRouter } from 'next/router';
+import { FormEvent, useRef } from 'react';
 import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
+import { UserChangePasswordRequest } from 'types/apis/user';
+import { ValueOf } from 'types/utility';
 
 const UserEditPasswordPage = () => {
   const { userId } = useRecoilValue(userAtom);
@@ -10,31 +14,33 @@ const UserEditPasswordPage = () => {
   return (
     <PageContainer>
       <Title>비밀번호 변경</Title>
-      <PasswordEditForm layout="vertical">
-        <FormItem label="현재 비밀번호">
+      <PasswordEditForm layout="vertical" form={form}>
+        <FormItem label="현재 비밀번호" name="oldPassword">
+          <Input type="password" onChange={(e) => handleChange('oldPassword', e.target.value)} />
+        </FormItem>
+        <FormItem label="비밀번호" name="newPassword">
+          <Input type="password" onChange={(e) => handleChange('newPassword', e.target.value)} />
+        </FormItem>
+        <FormItem label="비밀번호 확인" name="passwordCheck">
           <Input type="password" />
         </FormItem>
-        <FormItem label="비밀번호">
-          <Input type="password" />
-        </FormItem>
-        <FormItem label="비밀번호 확인">
-          <Input type="password" />
-        </FormItem>
-        <SubmitButton type="primary">변경</SubmitButton>
+        <SubmitButton type="primary" htmlType="submit" onClick={handleSubmit}>
+          변경
+        </SubmitButton>
       </PasswordEditForm>
 
       <SideNavigation
         paths={[
           {
-            href: `/users/${userId}`,
+            pathName: `/users/${userId}`,
             pageName: '사용자 정보',
           },
           {
-            href: `/users/${userId}/edit`,
+            pathName: `/users/${userId}/edit`,
             pageName: '프로필 수정',
           },
           {
-            href: `/users/${userId}/edit-password`,
+            pathName: `/users/${userId}/edit-password`,
             pageName: '비밀번호 변경',
           },
         ]}

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -133,16 +133,18 @@ const UserPage = ({ userInfoResponse, userReviewResponse }: UserPageProps) => {
       <SideNavigation
         paths={[
           {
-            href: `/users/${userInfo.userId}`,
+            pathName: `/users/${userInfo.userId}`,
             pageName: '사용자 정보',
           },
           {
-            href: `/users/${userInfo.userId}/edit`,
+            pathName: `/users/${userInfo.userId}/edit`,
             pageName: '프로필 수정',
+            query: userInfo, // TODO: 유저의 정보(nickname, profileImage)를 전역 데이터로 관리
           },
           {
-            href: `/users/${userInfo.userId}/edit-password`,
+            pathName: `/users/${userInfo.userId}/edit-password`,
             pageName: '비밀번호 변경',
+            query: userInfo,
           },
         ]}
       />
@@ -190,7 +192,8 @@ const ProfileContainer = styled.div`
 `;
 
 const ProfileImage = styled(Image)`
-  width: 200px;
+  width: 160px;
+  height: 160px;
   border-radius: 50%;
   margin-bottom: 20px;
 `;

--- a/types/apis/user/index.ts
+++ b/types/apis/user/index.ts
@@ -47,7 +47,7 @@ export interface UserInfoExhibitionLikeResponse extends BaseResponse {
 // }
 
 export interface UserInfoResponse extends BaseResponse {
-  data?: {
+  data: {
     nickname: string;
     userId: number;
     profileImage: string;
@@ -73,3 +73,8 @@ export interface UserCheckResponse extends BaseResponse {
 // users/me/info
 // users/me/info/exhibitions/like?
 // users/me/info/reviews/like?
+
+export interface UserChangePasswordRequest {
+  oldPassword: string;
+  newPassword: string;
+}

--- a/utils/formData/index.ts
+++ b/utils/formData/index.ts
@@ -1,18 +1,22 @@
 import type { UploadFile } from 'antd';
 
-export const objectToFormData = <T>(object: T, _formData?: FormData) => {
+export const objectToFormData = <T>(key: string, value: T, _formData?: FormData) => {
   const formData = _formData ? _formData : new FormData();
-  formData.append('data', new Blob([JSON.stringify({ ...object })], { type: 'application/json' }));
+  formData.append(key, new Blob([JSON.stringify({ ...value })], { type: 'application/json' }));
   return formData;
 };
 
-export const filesToFormData = (files: FileList | UploadFile[], _formData?: FormData) => {
+export const filesToFormData = (
+  key: string,
+  files: FileList | UploadFile[],
+  _formData?: FormData,
+) => {
   const formData = _formData ? _formData : new FormData();
   for (let i = 0; i < files.length; i++) {
     if ('originFileObj' in files[i]) {
-      formData.append('files', (files[i] as UploadFile).originFileObj as File); // TODO: 추후 files도 인자로 받을 예정
+      formData.append(key, (files[i] as UploadFile).originFileObj as File);
     } else {
-      formData.append('files', files[i] as File);
+      formData.append(key, files[i] as File);
     }
   }
   return formData;


### PR DESCRIPTION
# 작업 내용 (TODO)

프로필 사진, 닉네임 수정 기능을 구현했습니다. 

- [x] 프로필 사진, 닉네임 수정 기능 구현

# 사진 (구현 캡쳐)

https://user-images.githubusercontent.com/80658269/184428692-4eb81326-6c2d-4938-b001-66e46f2bf911.mp4

# 논의하고 싶은 부분

userId 외에 profileImage, nickname, email를 전역 데이터로 관리했으면 합니다. 
특히 유저 페이지에서 위 정보들이 필요합니다. 
현재 케이, 빈푸와 논의중입니다. 

close #158 
