### PR TITLE
refactor: 헤더에 로그인, 회원가입 메뉴가 보이도록 수정

### DIFF
--- a/components/atoms/LinkText/index.tsx
+++ b/components/atoms/LinkText/index.tsx
@@ -1,18 +1,36 @@
 import Link from 'next/link';
 import styled from '@emotion/styled';
-import { CSSProperties } from 'react';
+import { CSSProperties, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useTheme } from '@emotion/react';
 
 interface LinkTextProps {
   href: string;
   text: string;
+  highlight?: boolean;
+  highlightColor?: string;
   style?: CSSProperties;
-  isCurrentPage?: boolean;
 }
 
-const LinkText = ({ href, text, style, isCurrentPage }: LinkTextProps) => {
+const LinkText = ({ href, text, highlight = true, highlightColor, style }: LinkTextProps) => {
+  const [isCurrentPage, setIsCurrentPage] = useState(false);
+  const { pathname } = useRouter();
+  const theme = useTheme();
+
+  useEffect(() => {
+    if (!highlight) {
+      return;
+    }
+    setIsCurrentPage(href === pathname);
+  }, [highlight, href, pathname]);
+
   return (
     <Link href={href} passHref>
-      <StyledA style={style} isCurrentPage={isCurrentPage}>
+      <StyledA
+        isCurrentPage={isCurrentPage}
+        highlightColor={highlightColor || theme.color.blue.main}
+        style={style}
+      >
         {text}
       </StyledA>
     </Link>
@@ -21,17 +39,17 @@ const LinkText = ({ href, text, style, isCurrentPage }: LinkTextProps) => {
 
 const StyledA = styled.a<{
   isCurrentPage?: boolean;
+  highlightColor: string;
 }>`
   display: block;
   font-size: 2.2rem;
   white-space: nowrap;
 
-  ${({ isCurrentPage }) =>
+  ${({ isCurrentPage, highlightColor }) =>
     isCurrentPage &&
     ` 
-    color: #242f9b;
+    color: ${highlightColor};
     font-weight: 500;
-    border-bottom: 3px solid #242f9b;
   `}
 `;
 

--- a/components/organisms/Header/index.tsx
+++ b/components/organisms/Header/index.tsx
@@ -3,17 +3,19 @@ import Logo from 'components/atoms/Logo';
 import { Input, message, Image } from 'antd';
 import LinkText from 'components/atoms/LinkText';
 import { useRouter } from 'next/router';
-import { useRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
 import { useClickAway, useUserAuthActions } from 'hooks';
 import imageUrl from 'constants/imageUrl';
 import { useRef, useState } from 'react';
 
 const Header = () => {
-  const { pathname } = useRouter();
-  const [userState, setUserState] = useRecoilState(userAtom);
-  const { logout } = useUserAuthActions();
   const router = useRouter();
+  const { userId, profileImage, isLoggedIn } = useRecoilValue(userAtom);
+  console.log(isLoggedIn);
+
+  const { logout } = useUserAuthActions();
+
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const avatarContainer = useRef<HTMLDivElement>(null);
 
@@ -40,38 +42,40 @@ const Header = () => {
     <StyledHeader>
       <Container>
         <Logo width={180} height={55} />
-        <AvatarContainer ref={avatarContainer} onClick={handleAvatarClick}>
-          <Avatar src={userState.profileImage || imageUrl.USER_DEFAULT} preview={false} />
-          {isDropdownOpen && (
-            <Dropdown>
-              {userState.userId ? (
-                <>
-                  <LinkText href={`/users/${userState.userId}`} text="마이페이지" />
-                  <Button onClick={logout}>로그아웃</Button>
-                </>
-              ) : (
-                <>
-                  <LinkText href="/signin" text="로그인" />
-                  <LinkText href="/signup" text="회원가입" />
-                </>
-              )}
-            </Dropdown>
-          )}
-        </AvatarContainer>
+        {isLoggedIn ? (
+          <AvatarContainer ref={avatarContainer} onClick={handleAvatarClick}>
+            <Avatar src={profileImage || imageUrl.USER_DEFAULT} preview={false} />
+            {isDropdownOpen && (
+              <Dropdown>
+                <LinkText href={`/users/${userId}`} text="마이페이지" />
+                <Button onClick={logout}>로그아웃</Button>
+              </Dropdown>
+            )}
+          </AvatarContainer>
+        ) : (
+          <Utility>
+            <LinkText href="/signin" text="로그인" />
+            <LinkText href="/signup" text="회원가입" />
+          </Utility>
+        )}
       </Container>
       <Container>
         <Navigation>
           <LinkText
             href="/exhibitions/custom"
             text="맞춤 전시회"
-            isCurrentPage={pathname === '/exhibitions/custom'}
+            isCurrentPage={router.pathname === '/exhibitions/custom'}
           />
           <LinkText
             href="/reviews/create"
             text="후기 작성"
-            isCurrentPage={pathname === '/reviews/create'}
+            isCurrentPage={router.pathname === '/reviews/create'}
           />
-          <LinkText href="/community" text="커뮤니티" isCurrentPage={pathname === '/community'} />
+          <LinkText
+            href="/community"
+            text="커뮤니티"
+            isCurrentPage={router.pathname === '/community'}
+          />
         </Navigation>
         <SearchBar
           bordered={false}

--- a/components/organisms/Header/index.tsx
+++ b/components/organisms/Header/index.tsx
@@ -10,14 +10,11 @@ import imageUrl from 'constants/imageUrl';
 import { useRef, useState } from 'react';
 
 const Header = () => {
-  const router = useRouter();
   const { userId, profileImage, isLoggedIn } = useRecoilValue(userAtom);
-  console.log(isLoggedIn);
-
-  const { logout } = useUserAuthActions();
-
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const avatarContainer = useRef<HTMLDivElement>(null);
+  const { logout } = useUserAuthActions();
+  const router = useRouter();
 
   useClickAway(avatarContainer, () => {
     setIsDropdownOpen(false);
@@ -64,17 +61,14 @@ const Header = () => {
           <LinkText
             href="/exhibitions/custom"
             text="맞춤 전시회"
-            isCurrentPage={router.pathname === '/exhibitions/custom'}
           />
           <LinkText
             href="/reviews/create"
             text="후기 작성"
-            isCurrentPage={router.pathname === '/reviews/create'}
           />
           <LinkText
             href="/community"
             text="커뮤니티"
-            isCurrentPage={router.pathname === '/community'}
           />
         </Navigation>
         <SearchBar

--- a/constants/userLoginState.ts
+++ b/constants/userLoginState.ts
@@ -1,6 +1,7 @@
 export const SIGNOUT_USER_STATE = {
   userId: null,
   email: null,
-  nicknamae: null,
+  nickname: null,
   profileImage: null,
+  isLoggedIn: false,
 };

--- a/hooks/useUserAuthActions/index.ts
+++ b/hooks/useUserAuthActions/index.ts
@@ -18,7 +18,7 @@ function useUserAuthActions() {
       setToken('REFRESH_TOKEN', refreshToken);
       const { data } = await userAPI.getMyInfo();
       const { userId, email, nickname, profileImage } = data.data;
-      setUser({ userId, email, nickname, profileImage });
+      setUser({ userId, email, nickname, profileImage, isLoggedIn: true });
       message.success(res.data.message);
       router.push('/');
       // eslint-disable-next-line
@@ -39,7 +39,7 @@ function useUserAuthActions() {
       message.success('로그아웃 되었습니다.');
       router.push('/');
     } catch (e) {
-      message.error('로그아웃 실패'); // TODO: 에러 처리 보강
+      message.error('로그아웃 실패');
       throw e;
     }
   };

--- a/pages/oauth/callback/index.tsx
+++ b/pages/oauth/callback/index.tsx
@@ -22,7 +22,7 @@ const Callback = () => {
         setToken('ACCESS_TOKEN', accessToken.toString());
         const { data } = await userAPI.getMyInfo();
         const { userId, email, nickname, profileImage } = data.data;
-        setUser({ userId, email, nickname, profileImage });
+        setUser({ userId, email, nickname, profileImage, isLoggedIn: true });
         message.success('소셜 로그인 성공');
       }
     };

--- a/states/user.ts
+++ b/states/user.ts
@@ -26,7 +26,7 @@ const cookieEffect =
 
         const { data } = await userAPI.getMyInfo();
         const { userId, email, nickname, profileImage } = data.data;
-        return { userId, email, nickname, profileImage };
+        return { userId, email, nickname, profileImage, isLoggedIn: true };
       } catch (error: unknown) {
         cookie.remove('ACCESS_TOKEN');
         cookie.remove('REFRESH_TOKEN');
@@ -52,7 +52,7 @@ const userAtom = atom({
       try {
         const { data } = await userAPI.getMyInfo();
         const { userId, email, nickname, profileImage } = data.data;
-        return { userId, email, nickname, profileImage };
+        return { userId, email, nickname, profileImage, isLoggedIn: true };
       } catch (error: unknown) {
         cookie.remove('ACCESS_TOKEN');
         cookie.remove('REFRESH_TOKEN');


### PR DESCRIPTION
# 작업 내용 (TODO)

- [x] 헤더의 유저 아바타를 '로그인', '회원가입' 유틸 메뉴로 수정
- [x] userAtom에 isLoggedin 속성 추가

# 사진 (구현 캡쳐)

![image](https://user-images.githubusercontent.com/80658269/187037688-3bd420a8-948b-44d4-b00c-de9370feabac.png)

userAtom에 isLoggedIn 속성을 추가했습니다. 
유저의 로그인 여부를 판단할 때에는 되도록 isLoggedin을 사용해주시기 바랍니다. 

![image](https://user-images.githubusercontent.com/80658269/187037781-c0270ea6-7578-44e8-8eb2-ed1c63ba5da7.png)

# 논의하고 싶은 부분

close #239 
