### PR TITLE
fix: 헤더 검색 완료 시, value가 남아있는 버그 수정

### DIFF
--- a/components/organisms/Header/index.tsx
+++ b/components/organisms/Header/index.tsx
@@ -1,18 +1,19 @@
 import styled from '@emotion/styled';
 import Logo from 'components/atoms/Logo';
-import { Input, message, Image } from 'antd';
+import { Input, message, Image, InputRef } from 'antd';
 import LinkText from 'components/atoms/LinkText';
 import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
 import { useClickAway, useUserAuthActions } from 'hooks';
 import imageUrl from 'constants/imageUrl';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const Header = () => {
   const { userId, profileImage, isLoggedIn } = useRecoilValue(userAtom);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const avatarContainer = useRef<HTMLDivElement>(null);
+  const searchBar = useRef<InputRef>(null);
   const { logout } = useUserAuthActions();
   const router = useRouter();
 
@@ -34,6 +35,15 @@ const Header = () => {
       pathname: `/search-result/${value}`,
     });
   };
+
+  useEffect(() => {
+    if (router.pathname === '/search-result/[exhibition]') {
+      return;
+    }
+    if (searchBar.current && searchBar.current.input) {
+      searchBar.current.input.value = '';
+    }
+  }, [router.pathname]);
 
   return (
     <StyledHeader>
@@ -58,18 +68,9 @@ const Header = () => {
       </Container>
       <Container>
         <Navigation>
-          <LinkText
-            href="/exhibitions/custom"
-            text="맞춤 전시회"
-          />
-          <LinkText
-            href="/reviews/create"
-            text="후기 작성"
-          />
-          <LinkText
-            href="/community"
-            text="커뮤니티"
-          />
+          <LinkText href="/exhibitions/custom" text="맞춤 전시회" />
+          <LinkText href="/reviews/create" text="후기 작성" />
+          <LinkText href="/community" text="커뮤니티" />
         </Navigation>
         <SearchBar
           bordered={false}
@@ -78,6 +79,7 @@ const Header = () => {
           onSearch={handleSearchExhibition}
           size="large"
           enterButton={true}
+          ref={searchBar}
         />
       </Container>
     </StyledHeader>

--- a/pages/search-result/[exhibition]/index.tsx
+++ b/pages/search-result/[exhibition]/index.tsx
@@ -24,13 +24,15 @@ const SearchResultPage: NextPage = () => {
   }, [router.query]);
 
   useEffect(() => {
-    exhibitionAPI
-      .search(exhibition, currentPage, 10, true)
-      .then((res) => {
-        setTotal(res.data.data.totalPage);
-        setExhibitions(res.data.data.content);
-      })
-      .catch((err) => console.log(err));
+    if (exhibition) {
+      exhibitionAPI
+        .search(exhibition, currentPage, 10, true)
+        .then((res) => {
+          setTotal(res.data.data.totalPage);
+          setExhibitions(res.data.data.content);
+        })
+        .catch((err) => console.log(err));
+    }
   }, [currentPage, exhibition]);
 
   return (


### PR DESCRIPTION
# 작업 내용 (TODO)

헤더 검색 후, value가 남아있는 버그를 수정했습니다. 

1. 검색 결과 페이지인 경우, value가 그대로 남아있음
2. 다른 페이지인 경우, value가 사라짐
   (정확하게 말하면, 완전히 사라지는 것이 아니라 화면에만 안 보입니다.
    검색바에 포커스를 하면 value가 다시 나타납니다)

아래 영상을 참고해주시기 바랍니다. 

https://user-images.githubusercontent.com/80658269/187654626-33d90934-cc5e-42b8-9ff9-f1494df6a929.mp4






- [x] 헤더 검색 완료 후 value 처리 
- [x] exhibition이 빈 문자열일 때의 방어코드 추가

# 논의하고 싶은 부분

close #227 
