### PR TITLE
feat: useDebounceClick 커스텀 훅 구현

### DIFF
--- a/hooks/index.ts
+++ b/hooks/index.ts
@@ -4,3 +4,4 @@ export { default as useAxios } from './useAxios';
 export { default as useUserAuthActions } from './useUserAuthActions';
 export { default as useInput } from './useInput';
 export { default as useWithAuth } from './useWithAuth';
+export { default as useDebounceClick } from './useDebounce/click';

--- a/hooks/useDebounce/click.ts
+++ b/hooks/useDebounce/click.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+
+const useDebounceClick = <T extends HTMLElement = HTMLElement>(
+  handler: (e?: Event) => void,
+  ms: number,
+) => {
+  const timerId = useRef<ReturnType<typeof setTimeout>>();
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const listener = (e: Event) => {
+      timerId.current && clearTimeout(timerId.current);
+      timerId.current = setTimeout(() => {
+        handler(e);
+      }, ms);
+    };
+
+    const element = ref.current;
+    element && element.addEventListener('click', listener);
+
+    return () => {
+      element && element.removeEventListener('click', listener);
+      timerId.current && clearTimeout(timerId.current);
+    };
+  }, [handler, ms]);
+
+  return [ref];
+};
+
+export default useDebounceClick;

--- a/hooks/useDebounce/click.ts
+++ b/hooks/useDebounce/click.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 
 const useDebounceClick = <T extends HTMLElement = HTMLElement>(
   handler: (e?: Event) => void,
-  ms: number,
+  ms = 250,
 ) => {
   const timerId = useRef<ReturnType<typeof setTimeout>>();
   const ref = useRef<T>(null);

--- a/pages/reviews/create/index.tsx
+++ b/pages/reviews/create/index.tsx
@@ -12,7 +12,7 @@ import {
 } from 'utils';
 import imageUrl from 'constants/imageUrl';
 import { useRouter } from 'next/router';
-import { useClickAway, useWithAuth } from 'hooks';
+import { useClickAway, useWithAuth, useDebounceClick } from 'hooks';
 import { Spinner } from 'components/atoms';
 
 export interface SubmitData {
@@ -86,8 +86,8 @@ const ReviewCreatePage = () => {
     }
   };
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (e?: Event) => {
+    e?.preventDefault();
     if (validateReviewEditForm(submitData.current)) {
       let formData = convertObjectToFormData('data', submitData.current);
       formData = convertFilesToFormData('files', files, formData);
@@ -102,6 +102,7 @@ const ReviewCreatePage = () => {
       }
     }
   };
+  const [debounceRef] = useDebounceClick(handleSubmit, 300);
 
   const [isChecking] = useWithAuth();
   return isChecking ? (
@@ -184,7 +185,7 @@ const ReviewCreatePage = () => {
             {isPublic ? '전체 공개' : '비공개'}
           </FormItem>
 
-          <SubmitButton type="primary" onClick={handleSubmit}>
+          <SubmitButton type="primary" ref={debounceRef}>
             작성완료
           </SubmitButton>
         </ReviewEditForm>

--- a/pages/reviews/create/index.tsx
+++ b/pages/reviews/create/index.tsx
@@ -47,6 +47,7 @@ const ReviewCreatePage = () => {
   const [isPublic, setIsPublic] = useState(true);
   const router = useRouter();
   const { query } = router;
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if (query.exhibitionId) {
@@ -86,9 +87,14 @@ const ReviewCreatePage = () => {
     }
   };
 
-  const handleSubmit = async (e?: Event) => {
-    e?.preventDefault();
-    if (validateReviewEditForm(submitData.current)) {
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (isLoading) {
+      return;
+    }
+
+    if (!isLoading && validateReviewEditForm(submitData.current)) {
+      setIsLoading(true);
       let formData = convertObjectToFormData('data', submitData.current);
       formData = convertFilesToFormData('files', files, formData);
 
@@ -100,9 +106,9 @@ const ReviewCreatePage = () => {
         message.error(getErrorMessage(error));
         console.error(error);
       }
+      setIsLoading(false);
     }
   };
-  const [debounceRef] = useDebounceClick(handleSubmit, 300);
 
   const [isChecking] = useWithAuth();
   return isChecking ? (
@@ -185,7 +191,7 @@ const ReviewCreatePage = () => {
             {isPublic ? '전체 공개' : '비공개'}
           </FormItem>
 
-          <SubmitButton type="primary" ref={debounceRef}>
+          <SubmitButton type="primary" onClick={handleSubmit}>
             작성완료
           </SubmitButton>
         </ReviewEditForm>

--- a/pages/reviews/create/index.tsx
+++ b/pages/reviews/create/index.tsx
@@ -87,17 +87,13 @@ const ReviewCreatePage = () => {
     }
   };
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    if (isLoading) {
-      return;
-    }
+  const handleSubmit = async (e?: Event) => {
+    e?.preventDefault();
 
     if (!isLoading && validateReviewEditForm(submitData.current)) {
       setIsLoading(true);
       let formData = convertObjectToFormData('data', submitData.current);
       formData = convertFilesToFormData('files', files, formData);
-
       try {
         await reviewAPI.createReview(formData);
         message.success('후기 작성이 완료되었습니다.');
@@ -109,6 +105,7 @@ const ReviewCreatePage = () => {
       setIsLoading(false);
     }
   };
+  const [debounceRef] = useDebounceClick(handleSubmit, 300);
 
   const [isChecking] = useWithAuth();
   return isChecking ? (
@@ -191,7 +188,7 @@ const ReviewCreatePage = () => {
             {isPublic ? '전체 공개' : '비공개'}
           </FormItem>
 
-          <SubmitButton type="primary" onClick={handleSubmit}>
+          <SubmitButton type="primary" ref={debounceRef}>
             작성완료
           </SubmitButton>
         </ReviewEditForm>

--- a/pages/reviews/update/[id]/index.tsx
+++ b/pages/reviews/update/[id]/index.tsx
@@ -36,6 +36,7 @@ const ReviewUpdatePage = () => {
   const [isPublic, setIsPublic] = useState(true);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const clickedImage = useRef<number>(0);
+  const [isLoading, setIsLoading] = useState(false);
 
   const router = useRouter();
   const { response } = useAxios(() => reviewAPI.getReviewSingle(Number(router.query.id)), []);
@@ -85,7 +86,9 @@ const ReviewUpdatePage = () => {
 
   const handleSubmit = async (e?: Event) => {
     e?.preventDefault();
-    if (validateReviewEditForm(submitData.current)) {
+
+    if (!isLoading && validateReviewEditForm(submitData.current)) {
+      setIsLoading(true);
       let formData = convertObjectToFormData('data', submitData.current);
       formData = convertFilesToFormData('files', files, formData);
 
@@ -97,6 +100,7 @@ const ReviewUpdatePage = () => {
         message.error(getErrorMessage(error));
         console.error(error);
       }
+      setIsLoading(false);
     }
   };
   const [debounceRef] = useDebounceClick(handleSubmit, 300);

--- a/pages/reviews/update/[id]/index.tsx
+++ b/pages/reviews/update/[id]/index.tsx
@@ -11,7 +11,7 @@ import {
   validateReviewEditForm,
 } from 'utils';
 import { useRouter } from 'next/router';
-import { useAxios, useWithAuth } from 'hooks';
+import { useAxios, useWithAuth, useDebounceClick } from 'hooks';
 import moment from 'moment';
 import { PhotoProps } from 'types/model';
 import type { ReviewSingleReadData } from 'types/apis/review';
@@ -83,8 +83,8 @@ const ReviewUpdatePage = () => {
     setIsModalVisible(false);
   };
 
-  const handleSubmit = async (e: FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (e?: Event) => {
+    e?.preventDefault();
     if (validateReviewEditForm(submitData.current)) {
       let formData = convertObjectToFormData('data', submitData.current);
       formData = convertFilesToFormData('files', files, formData);
@@ -99,6 +99,7 @@ const ReviewUpdatePage = () => {
       }
     }
   };
+  const [debounceRef] = useDebounceClick(handleSubmit, 300);
 
   const [isChecking] = useWithAuth();
   if (isChecking) {
@@ -184,7 +185,7 @@ const ReviewUpdatePage = () => {
             {isPublic ? '전체 공개' : '비공개'}
           </FormItem>
 
-          <SubmitButton type="primary" onClick={handleSubmit}>
+          <SubmitButton type="primary" ref={debounceRef}>
             작성완료
           </SubmitButton>
         </ReviewEditForm>

--- a/pages/users/[id]/edit-password/index.tsx
+++ b/pages/users/[id]/edit-password/index.tsx
@@ -7,6 +7,7 @@ import { userAtom } from 'states';
 import { userAPI } from 'apis';
 import { AxiosError } from 'axios';
 import { validatePassword } from 'utils';
+import { useDebounceClick } from 'hooks';
 
 const UserEditPasswordPage = () => {
   const { userId } = useRecoilValue(userAtom);
@@ -21,6 +22,12 @@ const UserEditPasswordPage = () => {
     }
     return Promise.resolve();
   };
+
+  const handleSubmit = (e?: Event) => {
+    e?.preventDefault();
+    form.submit();
+  };
+  const [debounceRef] = useDebounceClick(handleSubmit, 300);
 
   const handleFinish = async () => {
     const { oldPassword, newPassword } = form.getFieldsValue();
@@ -88,7 +95,7 @@ const UserEditPasswordPage = () => {
         >
           <Input type="password" />
         </FormItem>
-        <SubmitButton type="primary" htmlType="submit">
+        <SubmitButton type="primary" ref={debounceRef}>
           변경
         </SubmitButton>
       </PasswordEditForm>

--- a/pages/users/[id]/edit/index.tsx
+++ b/pages/users/[id]/edit/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Button, Form, Input, Image, message } from 'antd';
-import { useState, useRef, ChangeEvent, MouseEvent } from 'react';
+import { useState, useRef, ChangeEvent } from 'react';
 import { SideNavigation } from 'components/molecules';
 import { useRecoilState } from 'recoil';
 import { userAtom } from 'states';

--- a/pages/users/[id]/edit/index.tsx
+++ b/pages/users/[id]/edit/index.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { Button, Form, Input, Image, message } from 'antd';
-import { useState, useRef, ChangeEvent } from 'react';
+import { useState, useRef, ChangeEvent, MouseEvent } from 'react';
 import { SideNavigation } from 'components/molecules';
 import { useRecoilState } from 'recoil';
 import { userAtom } from 'states';
@@ -12,6 +12,8 @@ import {
 } from 'utils';
 import { userAPI } from 'apis';
 import { AxiosError } from 'axios';
+import { useDebounceClick } from 'hooks';
+import { useForm } from 'antd/lib/form/Form';
 
 interface SubmitData {
   nickname: string;
@@ -19,6 +21,7 @@ interface SubmitData {
 }
 
 const UserEditPage = () => {
+  const [form] = useForm();
   const [userInfo, setUserInfo] = useRecoilState(userAtom);
   const { userId, nickname, profileImage } = userInfo;
   const submitData = useRef<SubmitData>({
@@ -43,6 +46,12 @@ const UserEditPage = () => {
       setPreviewImage(preview);
     }
   };
+
+  const handleSubmit = (e?: Event) => {
+    e?.preventDefault();
+    form.submit();
+  };
+  const [debounceRef] = useDebounceClick(handleSubmit, 300);
 
   const handleFinish = async () => {
     let formData = convertObjectToFormData('data', submitData.current);
@@ -74,6 +83,8 @@ const UserEditPage = () => {
     message.error('입력값을 다시 확인해주세요.');
   };
 
+
+
   return (
     <PageContainer>
       <Title>프로필 수정</Title>
@@ -81,6 +92,7 @@ const UserEditPage = () => {
         layout="vertical"
         onFinish={handleFinish}
         onFinishFailed={handleFinishFailed}
+        form={form}
       >
         <FormItem label="프로필 이미지">
           <ProfileImage
@@ -110,7 +122,7 @@ const UserEditPage = () => {
             }}
           />
         </FormItem>
-        <SubmitButton type="primary" htmlType="submit">
+        <SubmitButton type="primary" ref={debounceRef}>
           저장
         </SubmitButton>
       </ProfileEditForm>
@@ -179,6 +191,10 @@ const FileInput = styled.input``;
 const SubmitButton = styled(Button)`
   font-size: 1.6rem;
   margin-top: 4px;
+
+  span {
+    pointer-events: none;
+  }
 `;
 
 export default UserEditPage;


### PR DESCRIPTION
# 작업 내용 (TODO)

버튼 클릭의 연타를 방어하는 useDebounceClick 훅을 구현했습니다. 

- [x] useDebounceClick 훅 구현
- [x] 후기 생성 & 수정 페이지에 적용
- [x] 프로필 & 비밀번호 수정 페이지에 적용

## 기존 문제점

느린 네트워크 환경(Network Slow 3g)에서 
버튼을 연타하면 API가 여러 번 호출되는 문제가 있었습니다.  

https://user-images.githubusercontent.com/80658269/188132551-a780162a-3a03-4118-93c6-d0e09ee99a4e.mp4

useDebounceClick 훅을 적용해서 이 문제를 방어했습니다. 
버튼을 연타해도 클릭 이벤트 및 API가 여러 번 호출되지 않습니다. 

https://user-images.githubusercontent.com/80658269/188132650-ecb19c17-cec1-4e79-b08f-6867d77c921c.mp4

후기 생성 & 수정 페이지, 프로필 수정 페이지에 적용했습니다. 

close #256 
