### PR TITLE
refactor: ExhibitionCard와 ReviewCard의 props 수정 

### DIFF
--- a/components/molecules/ExhibitionCard/index.tsx
+++ b/components/molecules/ExhibitionCard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Card } from 'antd';
 import { HeartFilled, HeartOutlined, MessageOutlined } from '@ant-design/icons';
 import * as S from './style';
@@ -7,19 +7,19 @@ import { ExhibitionProps } from 'types/model';
 import { displayDday, displayFormattedDate } from 'utils';
 import Image from 'next/image';
 
-const { Meta } = Card;
+interface ExhibitionCardProps {
+  data: Required<ExhibitionProps>;
+}
 
-const ExhibitionCard = ({
-  exhibitionId,
-  name,
-  thumbnail,
-  startDate,
-  endDate,
-  likeCount,
-  reviewCount,
-  isLiked,
-}: Required<ExhibitionProps>) => {
+const ExhibitionCard = ({ data }: ExhibitionCardProps) => {
   const [isHover, setIsHover] = useState(false);
+
+  if (!data) {
+    return null;
+  }
+  const { exhibitionId, name, thumbnail, startDate, endDate, likeCount, reviewCount, isLiked } =
+    data;
+
   const dDay = displayDday(startDate);
   const mouseHover = () => setIsHover((isHover) => !isHover);
 

--- a/components/molecules/ReviewCard/index.tsx
+++ b/components/molecules/ReviewCard/index.tsx
@@ -6,41 +6,51 @@ import { displayDate } from 'utils';
 import { PhotoProps } from 'types/model';
 
 interface ReviewCardProps {
-  reviewId: number;
+  data: {
+    reviewId: number;
+    user: {
+      userId: number;
+      nickname: string;
+      profileImage: string;
+    };
+    title: string;
+    content: string;
+    createdAt: string;
+    likeCount: number;
+    commentCount: number;
+    photos: PhotoProps[] | null;
+  };
   thumbnail: string;
-  title: string;
-  content: string;
-  createdAt: string;
-  userId: number;
-  profileImage: string;
-  nickname: string;
-  likeCount: number;
-  commentCount: number;
-  photo: PhotoProps[] | null;
 }
 
-const ReviewCard = ({
-  reviewId,
-  thumbnail,
-  title,
-  content,
-  createdAt,
-  userId,
-  profileImage,
-  nickname,
-  likeCount,
-  commentCount,
-  photo,
-}: ReviewCardProps) => {
+const ReviewCard = ({ data, thumbnail }: ReviewCardProps) => {
   const [isHover, setIsHover] = useState(false);
   const mouseHover = () => setIsHover((isHover) => !isHover);
+
+  if (!data) {
+    return null;
+  }
+
+  const {
+    reviewId,
+    title,
+    content,
+    createdAt,
+    likeCount,
+    commentCount,
+    photos,
+    user: { userId, nickname, profileImage },
+  } = data;
 
   return (
     <Link href={`/reviews/detail/${reviewId}`}>
       <a>
         <S.ReviewCard>
           <S.PhotoWrapper onMouseEnter={mouseHover} onMouseLeave={mouseHover}>
-            <S.Photo preview={false} src={photo && photo.length > 0 ? photo[0].path : thumbnail} />
+            <S.Photo
+              preview={false}
+              src={photos && photos.length > 0 ? photos[0].path : thumbnail}
+            />
             {isHover ? (
               <S.HoverContent>
                 <HeartOutlined /> {likeCount} <MessageOutlined /> {commentCount}

--- a/components/organisms/Swiper/index.tsx
+++ b/components/organisms/Swiper/index.tsx
@@ -1,14 +1,13 @@
 import { Swiper, SwiperSlide } from 'swiper/react';
 import SwiperCore, { Navigation, Autoplay } from 'swiper';
 import * as S from './style';
-import React, { ReactElement } from 'react';
 import { ExhibitionProps } from 'types/model';
 import { ExhibitionCard } from 'components/molecules';
 
 SwiperCore.use([Navigation, Autoplay]);
 
 interface SwiperProps {
-  items: ExhibitionProps[];
+  items: Required<ExhibitionProps>[];
 }
 
 const SwiperWrapper = ({ items }: SwiperProps) => {
@@ -30,16 +29,7 @@ const SwiperWrapper = ({ items }: SwiperProps) => {
         >
           {items.map((item) => (
             <SwiperSlide key={item.exhibitionId} className="MyBanner__slideItem">
-              <ExhibitionCard
-                exhibitionId={item.exhibitionId}
-                name={item.name}
-                thumbnail={item.thumbnail}
-                startDate={item.startDate!}
-                endDate={item.endDate!}
-                likeCount={item.likeCount!}
-                reviewCount={item.reviewCount!}
-                isLiked={item.isLiked!}
-              />
+              <ExhibitionCard data={item} />
             </SwiperSlide>
           ))}
         </Swiper>

--- a/pages/exhibitions/custom/index.tsx
+++ b/pages/exhibitions/custom/index.tsx
@@ -11,7 +11,7 @@ import styled from '@emotion/styled';
 //exhibitions/custom
 const ExhibitionCustom: NextPage = () => {
   const [currentPage, setCurrentPage] = useState(0);
-  const [exhibitions, setExhibitions] = useState<ExhibitionProps[]>([]);
+  const [exhibitions, setExhibitions] = useState<Required<ExhibitionProps>[]>([]);
   const [selectedArea, setSelectedArea] = useState<{ id: number; value: string; name: string }[]>(
     [],
   );
@@ -74,17 +74,7 @@ const ExhibitionCustom: NextPage = () => {
       <S.ExhibitionsCustomContent>
         {exhibitions.length > 0 ? (
           exhibitions.map((exhibition) => (
-            <ExhibitionCard
-              exhibitionId={exhibition.exhibitionId}
-              key={exhibition.exhibitionId}
-              name={exhibition.name}
-              thumbnail={exhibition.thumbnail}
-              startDate={exhibition.startDate!}
-              endDate={exhibition.endDate!}
-              likeCount={exhibition.likeCount!}
-              reviewCount={exhibition.reviewCount!}
-              isLiked={exhibition.isLiked!}
-            />
+            <ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
           ))
         ) : (
           <div>

--- a/pages/exhibitions/detail/[id]/index.tsx
+++ b/pages/exhibitions/detail/[id]/index.tsx
@@ -76,20 +76,7 @@ const ExhibitionDetailPage = ({ data }: ExhibitionDetailResponse) => {
         {reviews && (
           <S.ReviewContainer>
             {reviews.map((review) => (
-              <ReviewCard
-                key={review.reviewId}
-                reviewId={review.reviewId}
-                thumbnail={thumbnail}
-                title={review.title}
-                content={review.content}
-                createdAt={review.createdAt}
-                likeCount={review.likeCount}
-                commentCount={review.commentCount}
-                photo={review.photos}
-                userId={review.user.userId}
-                nickname={review.user.nickname}
-                profileImage={review.user.profileImage}
-              ></ReviewCard>
+              <ReviewCard key={review.reviewId} data={review} thumbnail={thumbnail} />
             ))}
           </S.ReviewContainer>
         )}

--- a/pages/exhibitions/more/index.tsx
+++ b/pages/exhibitions/more/index.tsx
@@ -12,7 +12,7 @@ const ExhibitionsMore: NextPage = () => {
   const router = useRouter();
   const { type } = router.query;
   const [currentPage, setCurrentPage] = useState(0);
-  const [exhibitions, setExhibitions] = useState<ExhibitionProps[]>([]);
+  const [exhibitions, setExhibitions] = useState<Required<ExhibitionProps>[]>([]);
   const [total, setTotal] = useState(0);
 
   useEffect(() => {
@@ -50,17 +50,7 @@ const ExhibitionsMore: NextPage = () => {
       </div>
       <S.ExhibitionsMoreContent>
         {exhibitions.map((exhibition) => (
-          <ExhibitionCard
-            exhibitionId={exhibition.exhibitionId}
-            key={exhibition.exhibitionId}
-            name={exhibition.name}
-            thumbnail={exhibition.thumbnail}
-            startDate={exhibition.startDate!}
-            endDate={exhibition.endDate!}
-            likeCount={exhibition.likeCount!}
-            reviewCount={exhibition.reviewCount!}
-            isLiked={exhibition.isLiked!}
-          />
+          <ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
         ))}
       </S.ExhibitionsMoreContent>
       <Pagination

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,8 +11,8 @@ import { exhibitionAPI } from 'apis';
 import { ExhibitionProps } from 'types/model';
 
 interface HomeProps {
-  upcomingExhibitions: ExhibitionProps[];
-  mostLikeExhibitions: ExhibitionProps[];
+  upcomingExhibitions: Required<ExhibitionProps>[];
+  mostLikeExhibitions: Required<ExhibitionProps>[];
 }
 const Home: NextPage<HomeProps> = ({ upcomingExhibitions, mostLikeExhibitions }) => {
   return (

--- a/pages/search-result/[exhibition]/index.tsx
+++ b/pages/search-result/[exhibition]/index.tsx
@@ -13,7 +13,7 @@ const SearchResultPage: NextPage = () => {
   const router = useRouter();
   const [exhibition, setExhibition] = useState('');
   const [currentPage, setCurrentPage] = useState(0);
-  const [exhibitions, setExhibitions] = useState<ExhibitionProps[]>([]);
+  const [exhibitions, setExhibitions] = useState<Required<ExhibitionProps>[]>([]);
   const [total, setTotal] = useState(0);
 
   useEffect(() => {
@@ -43,17 +43,7 @@ const SearchResultPage: NextPage = () => {
       <S.SearchResultContents>
         {exhibitions.length > 0 ? (
           exhibitions.map((exhibition) => (
-            <ExhibitionCard
-              exhibitionId={exhibition.exhibitionId}
-              key={exhibition.exhibitionId}
-              name={exhibition.name}
-              thumbnail={exhibition.thumbnail}
-              startDate={exhibition.startDate!}
-              endDate={exhibition.endDate!}
-              likeCount={exhibition.likeCount!}
-              reviewCount={exhibition.reviewCount!}
-              isLiked={exhibition.isLiked!}
-            />
+            <ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
           ))
         ) : (
           <div>

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -126,17 +126,8 @@ const UserPage = () => {
             {myReview.payload?.map((review) => (
               <ReviewCard
                 key={review.reviewId}
-                reviewId={review.reviewId}
-                title={review.title}
-                content={review.content}
+                data={review}
                 thumbnail={review.exhibition.thumbnail}
-                createdAt={review.createdAt}
-                likeCount={review.likeCount}
-                commentCount={review.commentCount}
-                photo={review.photos}
-                userId={review.user.userId}
-                nickname={review.user.nickname}
-                profileImage={review.user.profileImage}
               />
             ))}
           </ReviewContainer>
@@ -155,17 +146,8 @@ const UserPage = () => {
               likedReview.payload.map((review) => (
                 <ReviewCard
                   key={review.reviewId}
-                  reviewId={review.reviewId}
-                  title={review.title}
-                  content={review.content}
+                  data={review}
                   thumbnail={review.exhibition.thumbnail}
-                  createdAt={review.createdAt}
-                  likeCount={review.likeCount}
-                  commentCount={review.commentCount}
-                  photo={review.photos}
-                  userId={review.user.userId}
-                  nickname={review.user.nickname}
-                  profileImage={review.user.profileImage}
                 />
               ))
             ) : (

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -167,17 +167,7 @@ const UserPage = () => {
           <ExhibitionContainer>
             {likedExhibition ? (
               likedExhibition.payload.map((exhibition) => (
-                <ExhibitionCard
-                  key={exhibition.exhibitionId}
-                  exhibitionId={exhibition.exhibitionId}
-                  name={exhibition.name}
-                  thumbnail={exhibition.thumbnail}
-                  startDate={exhibition.startDate}
-                  endDate={exhibition.endDate}
-                  likeCount={exhibition.likeCount}
-                  reviewCount={exhibition.reviewCount}
-                  isLiked={exhibition.isLiked}
-                />
+                <ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
               ))
             ) : (
               <Spinner size="large" />

--- a/types/model.ts
+++ b/types/model.ts
@@ -1,5 +1,4 @@
 import { ReviewSingleReadData } from './apis/review/index';
-import { CSSProperties } from 'react';
 
 export interface ExhibitionProps {
   exhibitionId: number;
@@ -77,6 +76,7 @@ export interface PhotoProps {
 export interface UserAtomProps {
   userId: number | null;
   email: string | null;
-  nicknamae: string | null;
+  nickname: string | null;
   profileImage: string | null;
+  isLoggedIn: boolean;
 }


### PR DESCRIPTION
# 작업 내용 (TODO)

ExhibitionCard와 ReviewCard의 props를 수정했습니다. 

## 문제점
ExhibitionCard와 ReviewCard 사용 시 아래와 같이 
데이터를 하나씩 주입해주는 방식을 취하고 있습니다. 

```tsx
<ExhibitionCard
  exhibitionId={exhibition.exhibitionId}
  key={exhibition.exhibitionId}
  name={exhibition.name}
  thumbnail={exhibition.thumbnail}
  startDate={exhibition.startDate!}
  endDate={exhibition.endDate!}
  likeCount={exhibition.likeCount!}
  reviewCount={exhibition.reviewCount!}
  isLiked={exhibition.isLiked!}
/>
```

컴포넌트를 사용하는 입장에서 많이 불편한 방식입니다. 
(멘토님께서 중간 피드백에서 지적해주신 내용입니다)

아래와 같이 데이터를 한꺼번에 넘기는 방식으로 리팩토링했습니다. 

```tsx
<ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
```

전달된 데이터는 해당 컴포넌트 내부에서 디스트럭처링합니다. 

```tsx
// exhibitionCard
  const { exhibitionId, name, thumbnail, startDate, endDate, likeCount, reviewCount, isLiked } =
    data;
```

- [x] ExhibitionCard의 props 수정
- [x] ReviewCard의 props 수정

# 논의하고 싶은 부분

@Hyevvy  @yunjjeongjo 
두 분께서 작성하셨던 코드를 수정한 것입니다. 
그러므로 이번 PR은 리뷰를 꼭 부탁합니다. 
피드백 반영하겠습니다. 

수정 후, 로컬 서버에서 정상 동작하는 것을 확인했습니다. 
그래도 브랜치에 한 번씩 들어오셔서 확인해주시면 감사하겠습니다. 

close #259
