### PR TITLE
hotfix: 유저 profileImage 기본 이미지 추가

### DIFF
--- a/components/atoms/UserAvatar/index.tsx
+++ b/components/atoms/UserAvatar/index.tsx
@@ -1,13 +1,13 @@
 import styled from '@emotion/styled';
 import { Avatar } from 'antd';
 import Link from 'next/link';
-import defaultImage from 'constants/defaultImage';
+import DEFAULT_IMAGE from 'constants/defaultImage';
 
 const UserAvatar = ({ userId, profileImage }: { userId: number; profileImage: string }) => {
   return (
     <Link href={`/users/${userId}`}>
       <a>
-        <StyledAvatar src={profileImage || defaultImage.USER_PROFILE} />
+        <StyledAvatar src={profileImage || DEFAULT_IMAGE.USER_PROFILE} />
       </a>
     </Link>
   );

--- a/components/atoms/UserAvatar/index.tsx
+++ b/components/atoms/UserAvatar/index.tsx
@@ -1,12 +1,13 @@
 import styled from '@emotion/styled';
 import { Avatar } from 'antd';
 import Link from 'next/link';
+import defaultImage from 'constants/defaultImage';
 
 const UserAvatar = ({ userId, profileImage }: { userId: number; profileImage: string }) => {
   return (
     <Link href={`/users/${userId}`}>
       <a>
-        <StyledAvatar src={profileImage} />
+        <StyledAvatar src={profileImage || defaultImage.USER_PROFILE} />
       </a>
     </Link>
   );

--- a/components/molecules/ReviewCard/index.tsx
+++ b/components/molecules/ReviewCard/index.tsx
@@ -4,7 +4,7 @@ import * as S from './style';
 import Link from 'next/link';
 import { displayDate } from 'utils';
 import { PhotoProps } from 'types/model';
-import defaultImage from 'constants/defaultImage';
+import DEFAULT_IMAGE from 'constants/defaultImage';
 
 interface ReviewCardProps {
   reviewId: number;
@@ -50,7 +50,7 @@ const ReviewCard = ({
           </S.PhotoWrapper>
           <S.UserInfoContainer>
             <Link href={`/users/${userId}`}>
-              <S.UserInfoAvatar src={profileImage || defaultImage.USER_PROFILE} size={60} />
+              <S.UserInfoAvatar src={profileImage || DEFAULT_IMAGE.USER_PROFILE} size={60} />
             </Link>
             <S.UserInfoTextContainer>
               <Link href={`/users/${userId}`}>

--- a/components/molecules/ReviewCard/index.tsx
+++ b/components/molecules/ReviewCard/index.tsx
@@ -4,6 +4,7 @@ import * as S from './style';
 import Link from 'next/link';
 import { displayDate } from 'utils';
 import { PhotoProps } from 'types/model';
+import defaultImage from 'constants/defaultImage';
 
 interface ReviewCardProps {
   reviewId: number;
@@ -49,7 +50,7 @@ const ReviewCard = ({
           </S.PhotoWrapper>
           <S.UserInfoContainer>
             <Link href={`/users/${userId}`}>
-              <S.UserInfoAvatar src={profileImage} size={60} />
+              <S.UserInfoAvatar src={profileImage || defaultImage.USER_PROFILE} size={60} />
             </Link>
             <S.UserInfoTextContainer>
               <Link href={`/users/${userId}`}>

--- a/components/organisms/Header/index.tsx
+++ b/components/organisms/Header/index.tsx
@@ -7,7 +7,7 @@ import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
 import { useClickAway, useUserAuthActions } from 'hooks';
 import { useEffect, useRef, useState } from 'react';
-import defaultImage from 'constants/defaultImage';
+import DEFAULT_IMAGE from 'constants/defaultImage';
 
 const Header = () => {
   const { userId, profileImage, isLoggedIn } = useRecoilValue(userAtom);
@@ -51,7 +51,7 @@ const Header = () => {
         <Logo width={180} height={55} />
         {isLoggedIn ? (
           <AvatarContainer ref={avatarContainer} onClick={handleAvatarClick}>
-            <Avatar src={profileImage || defaultImage.USER_PROFILE} preview={false} />
+            <Avatar src={profileImage || DEFAULT_IMAGE.USER_PROFILE} preview={false} />
             {isDropdownOpen && (
               <Dropdown>
                 <LinkText href={`/users/${userId}`} text="마이페이지" />

--- a/components/organisms/Header/index.tsx
+++ b/components/organisms/Header/index.tsx
@@ -6,8 +6,8 @@ import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
 import { useClickAway, useUserAuthActions } from 'hooks';
-import imageUrl from 'constants/imageUrl';
 import { useEffect, useRef, useState } from 'react';
+import defaultImage from 'constants/defaultImage';
 
 const Header = () => {
   const { userId, profileImage, isLoggedIn } = useRecoilValue(userAtom);
@@ -51,7 +51,7 @@ const Header = () => {
         <Logo width={180} height={55} />
         {isLoggedIn ? (
           <AvatarContainer ref={avatarContainer} onClick={handleAvatarClick}>
-            <Avatar src={profileImage || imageUrl.USER_DEFAULT} preview={false} />
+            <Avatar src={profileImage || defaultImage.USER_PROFILE} preview={false} />
             {isDropdownOpen && (
               <Dropdown>
                 <LinkText href={`/users/${userId}`} text="마이페이지" />

--- a/constants/defaultImage.ts
+++ b/constants/defaultImage.ts
@@ -1,8 +1,8 @@
-const imageUrl = {
-  USER_DEFAULT:
+const defaultImage = {
+  USER_PROFILE:
     'https://user-images.githubusercontent.com/80658269/185602729-74e474d1-250a-4403-a5eb-d1e3ef3da863.png',
-  EXHIBITION_DEFAULT:
+  EXHIBITION_THUMBNAIL:
     'https://raw.githubusercontent.com/gitul0515/gitul0515.github.io/main/_posts/image/poster-default-image.png',
 };
 
-export default imageUrl;
+export default defaultImage;

--- a/constants/defaultImage.ts
+++ b/constants/defaultImage.ts
@@ -1,8 +1,8 @@
-const defaultImage = {
+const DEFAULT_IMAGE = {
   USER_PROFILE:
     'https://user-images.githubusercontent.com/80658269/185602729-74e474d1-250a-4403-a5eb-d1e3ef3da863.png',
   EXHIBITION_THUMBNAIL:
     'https://raw.githubusercontent.com/gitul0515/gitul0515.github.io/main/_posts/image/poster-default-image.png',
 };
 
-export default defaultImage;
+export default DEFAULT_IMAGE;

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -2,4 +2,4 @@ export { SIGNOUT_USER_STATE } from './userLoginState';
 export { default as exhibitionPeriod } from './exhibitionPeriod';
 export { default as exhibitionPlace } from './exhibitionPlace';
 export { default as exhibitionGenre } from './exhibitionGenre';
-export { default as defaultImage } from './defaultImage';
+export { default as DEFAULT_IMAGE } from './defaultImage';

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -2,3 +2,4 @@ export { SIGNOUT_USER_STATE } from './userLoginState';
 export { default as exhibitionPeriod } from './exhibitionPeriod';
 export { default as exhibitionPlace } from './exhibitionPlace';
 export { default as exhibitionGenre } from './exhibitionGenre';
+export { default as defaultImage } from './defaultImage';

--- a/pages/reviews/create/index.tsx
+++ b/pages/reviews/create/index.tsx
@@ -10,7 +10,7 @@ import {
   getErrorMessage,
   validateReviewEditForm,
 } from 'utils';
-import imageUrl from 'constants/imageUrl';
+import defaultImage from 'constants/defaultImage';
 import { useRouter } from 'next/router';
 import { useClickAway, useWithAuth, useDebounceClick } from 'hooks';
 import { Spinner } from 'components/atoms';
@@ -43,7 +43,7 @@ const ReviewCreatePage = () => {
   const submitData = useRef<SubmitData>({ ...initialData });
   const [files, setFiles] = useState<UploadFile[]>([]);
   const [searchResults, setSearchResults] = useState<SearchResult[]>();
-  const [posterImage, setPosterImage] = useState(imageUrl.EXHIBITION_DEFAULT);
+  const [posterImage, setPosterImage] = useState(defaultImage.EXHIBITION_THUMBNAIL);
   const [isPublic, setIsPublic] = useState(true);
   const router = useRouter();
   const { query } = router;
@@ -145,7 +145,7 @@ const ReviewCreatePage = () => {
               <Poster
                 src={posterImage}
                 alt="전시회 포스터 이미지"
-                preview={posterImage !== imageUrl.EXHIBITION_DEFAULT}
+                preview={posterImage !== defaultImage.EXHIBITION_THUMBNAIL}
               />
             </SearchContainer>
           </FormItem>

--- a/pages/reviews/create/index.tsx
+++ b/pages/reviews/create/index.tsx
@@ -10,10 +10,11 @@ import {
   getErrorMessage,
   validateReviewEditForm,
 } from 'utils';
-import defaultImage from 'constants/defaultImage';
 import { useRouter } from 'next/router';
 import { useClickAway, useWithAuth, useDebounceClick } from 'hooks';
 import { Spinner } from 'components/atoms';
+import DEFAULT_IMAGE from 'constants/defaultImage';
+
 
 export interface SubmitData {
   exhibitionId: number;
@@ -43,7 +44,7 @@ const ReviewCreatePage = () => {
   const submitData = useRef<SubmitData>({ ...initialData });
   const [files, setFiles] = useState<UploadFile[]>([]);
   const [searchResults, setSearchResults] = useState<SearchResult[]>();
-  const [posterImage, setPosterImage] = useState(defaultImage.EXHIBITION_THUMBNAIL);
+  const [posterImage, setPosterImage] = useState(DEFAULT_IMAGE.EXHIBITION_THUMBNAIL);
   const [isPublic, setIsPublic] = useState(true);
   const router = useRouter();
   const { query } = router;
@@ -145,7 +146,7 @@ const ReviewCreatePage = () => {
               <Poster
                 src={posterImage}
                 alt="전시회 포스터 이미지"
-                preview={posterImage !== defaultImage.EXHIBITION_THUMBNAIL}
+                preview={posterImage !== DEFAULT_IMAGE.EXHIBITION_THUMBNAIL}
               />
             </SearchContainer>
           </FormItem>

--- a/pages/users/[id]/edit/index.tsx
+++ b/pages/users/[id]/edit/index.tsx
@@ -14,7 +14,7 @@ import { userAPI } from 'apis';
 import { AxiosError } from 'axios';
 import { useDebounceClick } from 'hooks';
 import { useForm } from 'antd/lib/form/Form';
-import defaultImage from 'constants/defaultImage';
+import DEFAULT_IMAGE from 'constants/defaultImage';
 
 interface SubmitData {
   nickname: string;
@@ -95,7 +95,7 @@ const UserEditPage = () => {
       >
         <FormItem label="프로필 이미지">
           <ProfileImage
-            src={previewImage || defaultImage.USER_PROFILE}
+            src={previewImage || DEFAULT_IMAGE.USER_PROFILE}
             alt="profile image"
             onClick={handleImageClick}
             preview={false}

--- a/pages/users/[id]/edit/index.tsx
+++ b/pages/users/[id]/edit/index.tsx
@@ -14,6 +14,7 @@ import { userAPI } from 'apis';
 import { AxiosError } from 'axios';
 import { useDebounceClick } from 'hooks';
 import { useForm } from 'antd/lib/form/Form';
+import defaultImage from 'constants/defaultImage';
 
 interface SubmitData {
   nickname: string;
@@ -83,8 +84,6 @@ const UserEditPage = () => {
     message.error('입력값을 다시 확인해주세요.');
   };
 
-
-
   return (
     <PageContainer>
       <Title>프로필 수정</Title>
@@ -96,7 +95,7 @@ const UserEditPage = () => {
       >
         <FormItem label="프로필 이미지">
           <ProfileImage
-            src={previewImage}
+            src={previewImage || defaultImage.USER_PROFILE}
             alt="profile image"
             onClick={handleImageClick}
             preview={false}

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -6,6 +6,7 @@ import { CSSProperties, useEffect, useState } from 'react';
 import { ReviewCardProps, ExhibitionProps } from 'types/model';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
+import defaultImage from 'constants/defaultImage';
 
 interface UserActivity<T> {
   payload: T[];
@@ -116,7 +117,7 @@ const UserPage = () => {
   return (
     <PageContainer>
       <ProfileContainer>
-        <ProfileImage src={profileImage} alt="프로필 이미지" />
+        <ProfileImage src={profileImage || defaultImage.USER_PROFILE} alt="프로필 이미지" />
         <UserName>{nickname}</UserName>
         <UserEmail>{email}</UserEmail>
       </ProfileContainer>

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -6,7 +6,7 @@ import { CSSProperties, useEffect, useState } from 'react';
 import { ReviewCardProps, ExhibitionProps } from 'types/model';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
-import defaultImage from 'constants/defaultImage';
+import DEFAULT_IMAGE from 'constants/defaultImage';
 
 interface UserActivity<T> {
   payload: T[];
@@ -117,7 +117,7 @@ const UserPage = () => {
   return (
     <PageContainer>
       <ProfileContainer>
-        <ProfileImage src={profileImage || defaultImage.USER_PROFILE} alt="프로필 이미지" />
+        <ProfileImage src={profileImage || DEFAULT_IMAGE.USER_PROFILE} alt="프로필 이미지" />
         <UserName>{nickname}</UserName>
         <UserEmail>{email}</UserEmail>
       </ProfileContainer>


### PR DESCRIPTION
# 작업 내용 (TODO)

유저의 profileImage 디폴트 값이 빈 문자열('')로 변경되었습니다.
이에 아래와 같은 기본 이미지를 추가했습니니다.

- [x] 유저 profileImage 기본 이미지 추가
- [x] UserAvtar 컴포넌트에 적용
- [x] ReviewCard 컴포넌트에 적용 (전시회 상세)
- [x] 헤더, 유저 페이지, 프로필 수정 페이지에 적용

close #264
