### PR TITLE
fix: 커뮤니티 페이지와 리뷰 상세 페이지의 좋아요 버그 수정

### DIFF
--- a/components/organisms/ReviewDetail/index.tsx
+++ b/components/organisms/ReviewDetail/index.tsx
@@ -3,7 +3,7 @@ import { reviewAPI } from 'apis';
 import { LinkButton } from 'components/atoms';
 import { UserInfo, ImageGroup, ReviewExhibitionInfo } from 'components/molecules';
 import { InfoGroup } from 'components/organisms';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
 import { ReviewSingleReadData } from 'types/apis/review';
@@ -36,6 +36,11 @@ const ReviewDetail = ({ reviewDetail, commentCount, onDeleteButtonClick }: Revie
   const [isLikeDetail, setIsLikedFeed] = useState(isLiked);
   const [likeLoading, setLikeLoading] = useState(false);
   const userState = useRecoilValue(userAtom);
+
+  useEffect(() => {
+    setIsLikedFeed(isLiked);
+    setDetailLikeCount(likeCount);
+  }, [isLiked, likeCount]);
 
   const handleLikeClick = async (reviewId: number) => {
     if (!userState.userId) {

--- a/components/organisms/ReviewFeed/index.tsx
+++ b/components/organisms/ReviewFeed/index.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/router';
 import { ReviewFeedProps } from 'types/model';
 import { InfoGroup } from 'components/organisms';
 import { LinkButton } from 'components/atoms';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
 import { reviewAPI } from 'apis';
@@ -31,6 +31,11 @@ const ReviewFeed = ({ feed, isMyFeed, onDeleteButtonClick }: ReviewFeedProps) =>
   const [feedLikeCount, setFeedLikeCount] = useState(likeCount);
   const [likeLoading, setLikeLoading] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false);
+
+  useEffect(() => {
+    setIsLikedFeed(isLiked);
+    setFeedLikeCount(likeCount);
+  }, [isLiked, likeCount]);
 
   const showModal = () => {
     setIsModalVisible(true);


### PR DESCRIPTION
# 작업 내용 (TODO)

커뮤니티 페이지와 리뷰 디테일에서 나타는 **SWR 캐시 문제로 발생한 좋아요 버그를 수정**하였습니다. 

- [x] ReviewDetail 컴포넌트에서의 좋아요 버그 수정
- [x] ReivewFeed 컴포넌트에서의 좋아요 버그 수정

# 사진 (구현 캡쳐)

실제 페이지에서 동작을 확인 부탁드립니다!

# 논의하고 싶은 부분

이전 데이터를 캐시한다는 SWR의 특징때문에 아주 잠깐 동안 이전의 데이터가 보이는 현상이 있습니다.
![이전데이터](https://user-images.githubusercontent.com/74234333/191286666-4e3d0333-980a-4339-8338-07aee0729fb3.gif)

컴퓨터의 성능에 따라, 시간이 얼마나 소요될지는 모르겠으나 어느정도 UX에 영향을 주는 요소라고 생각됩니다.
한편으로는, SWR의 빠른 성능과 어느정도 trade-off 관계를 가질 수도 있겠다는 생각이 드네요.

`useSWR` 을 그대로 사용할지, 아니면 원래의 `useEffect` 코드로 돌아갈지, 여러분들과 논의 하고 싶습니다.

close #282
