### PR TITLE
refactor: 후기 작성 페이지 컴포넌트 분리 및 SWR 적용

### DIFF
--- a/components/organisms/ExhibitionSearchBar/index.tsx
+++ b/components/organisms/ExhibitionSearchBar/index.tsx
@@ -10,11 +10,12 @@ import { ValueOf } from 'types/utility';
 import { SubmitData } from 'pages/reviews/create';
 
 interface ExhibitionSearchBarProps {
-  query: {
+  prevData: {
     name?: string;
     thumbnail?: string;
   };
-  onExhibitionChange: (key: string, value: ValueOf<SubmitData>) => void;
+  onExhibitionChange?: (key: string, value: ValueOf<SubmitData>) => void;
+  disabled?: boolean;
 }
 
 interface SearchResult {
@@ -23,11 +24,15 @@ interface SearchResult {
   thumbnail: string;
 }
 
-const ExhibitionSearchBar = ({ query, onExhibitionChange }: ExhibitionSearchBarProps) => {
+const ExhibitionSearchBar = ({
+  prevData,
+  onExhibitionChange,
+  disabled = false,
+}: ExhibitionSearchBarProps) => {
   const [searchWord, setSearchWord] = useState('');
-  const [exhibitionName, setExhibitionName] = useState((query.name as string) || '');
+  const [exhibitionName, setExhibitionName] = useState((prevData.name as string) || '');
   const [posterImage, setPosterImage] = useState(
-    query.thumbnail || DEFAULT_IMAGE.EXHIBITION_THUMBNAIL,
+    prevData.thumbnail || DEFAULT_IMAGE.EXHIBITION_THUMBNAIL,
   );
   const [searchResults, setSearchResults] = useState<SearchResult[]>();
   const resultList = useRef<HTMLUListElement>(null);
@@ -64,13 +69,14 @@ const ExhibitionSearchBar = ({ query, onExhibitionChange }: ExhibitionSearchBarP
             setExhibitionName('');
             resultList.current && show(resultList.current);
           }}
+          disabled={disabled}
         />
         <ResultList ref={resultList}>
           {searchResults?.map(({ exhibitionId, name, thumbnail }) => (
             <ResultItem
               key={exhibitionId}
               onClick={() => {
-                onExhibitionChange('exhibitionId', exhibitionId);
+                onExhibitionChange && onExhibitionChange('exhibitionId', exhibitionId);
                 setExhibitionName(name);
                 setPosterImage(thumbnail);
                 resultList.current && hide(resultList.current);

--- a/components/organisms/ExhibitionSearchBar/index.tsx
+++ b/components/organisms/ExhibitionSearchBar/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import styled from '@emotion/styled';
 import { Input, Image, message } from 'antd';
 import DEFAULT_IMAGE from 'constants/defaultImage';
@@ -15,7 +14,6 @@ interface ExhibitionSearchBarProps {
     thumbnail?: string;
   };
   onExhibitionChange?: (key: string, value: ValueOf<SubmitData>) => void;
-  disabled?: boolean;
 }
 
 interface SearchResult {
@@ -24,11 +22,7 @@ interface SearchResult {
   thumbnail: string;
 }
 
-const ExhibitionSearchBar = ({
-  prevData,
-  onExhibitionChange,
-  disabled = false,
-}: ExhibitionSearchBarProps) => {
+const ExhibitionSearchBar = ({ prevData, onExhibitionChange }: ExhibitionSearchBarProps) => {
   const [searchWord, setSearchWord] = useState('');
   const [exhibitionName, setExhibitionName] = useState((prevData.name as string) || '');
   const [posterImage, setPosterImage] = useState(
@@ -69,7 +63,7 @@ const ExhibitionSearchBar = ({
             setExhibitionName('');
             resultList.current && show(resultList.current);
           }}
-          disabled={disabled}
+          disabled={!!prevData.name}
         />
         <ResultList ref={resultList}>
           {searchResults?.map(({ exhibitionId, name, thumbnail }) => (
@@ -126,7 +120,7 @@ const ResultList = styled.ul`
   max-height: 168px;
   border: 1px solid ${({ theme }) => theme.color.border.light};
   position: relative;
-  top: -2px;
+  top: -3px;
   overflow-y: auto;
   background-color: ${({ theme }) => theme.color.white};
 `;
@@ -143,4 +137,4 @@ const Poster = styled(Image)`
   flex-shrink: 0;
 `;
 
-export default React.memo(ExhibitionSearchBar);
+export default ExhibitionSearchBar;

--- a/components/organisms/ExhibitionSearchBar/index.tsx
+++ b/components/organisms/ExhibitionSearchBar/index.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Input, Image, message } from 'antd';
+import DEFAULT_IMAGE from 'constants/defaultImage';
+import { useState, useRef, useCallback } from 'react';
+import { getErrorMessage, show, hide } from 'utils';
+import { useDebounce } from 'hooks';
+import { reviewAPI } from 'apis';
+
+interface ExhibitionSearchBarProps {
+  query: {
+    name?: string;
+    thumbnail?: string;
+  };
+}
+
+interface SearchResult {
+  exhibitionId: number;
+  name: string;
+  thumbnail: string;
+}
+
+const ExhibitionSearchBar = ({ query }: ExhibitionSearchBarProps) => {
+  const [searchWord, setSearchWord] = useState('');
+  const [exhibitionName, setExhibitionName] = useState((query.name as string) || '');
+  const [posterImage, setPosterImage] = useState(
+    query.thumbnail || DEFAULT_IMAGE.EXHIBITION_THUMBNAIL,
+  );
+  const [searchResults, setSearchResults] = useState<SearchResult[]>(); //
+  const resultList = useRef<HTMLUListElement>(null);
+
+  const handleSearch = useCallback(async () => {
+    const isEmpty = !/\S/.test(searchWord);
+    if (isEmpty) {
+      setSearchResults([]);
+      return;
+    }
+    try {
+      const { data } = await reviewAPI.searchExhibition(searchWord);
+      const { exhibitions } = data.data;
+      setSearchResults([...exhibitions]);
+      resultList.current && show(resultList.current);
+      !exhibitions.length && message.warning('검색 결과가 없습니다.');
+    } catch (error) {
+      message.error(getErrorMessage(error));
+      console.error(error);
+    }
+  }, [searchWord]);
+  useDebounce(handleSearch, 500, searchWord);
+
+  return (
+    <SearchContainer>
+      <InnerContainer>
+        <SearchBar
+          placeholder="전시회 제목을 검색해 주세요"
+          value={exhibitionName || searchWord}
+          onChange={(e) => {
+            setSearchWord(e.target.value);
+          }}
+          onFocus={() => {
+            setExhibitionName('');
+            resultList.current && show(resultList.current);
+          }}
+        />
+        <ResultList ref={resultList}>
+          {searchResults?.map(({ exhibitionId, name, thumbnail }) => (
+            <ResultItem
+              key={exhibitionId}
+              onClick={() => {
+                // submitData.current['exhibitionId'] = exhibitionId;
+                setPosterImage(thumbnail);
+                setExhibitionName(name);
+                resultList.current && hide(resultList.current);
+              }}
+            >
+              {name}
+            </ResultItem>
+          ))}
+        </ResultList>
+      </InnerContainer>
+      <Poster
+        src={posterImage}
+        alt="전시회 포스터 이미지"
+        preview={posterImage !== DEFAULT_IMAGE.EXHIBITION_THUMBNAIL}
+      />
+    </SearchContainer>
+  );
+};
+
+const SearchContainer = styled.div`
+  width: 100%;
+  display: flex;
+`;
+
+const InnerContainer = styled.div`
+  width: 100%;
+  height: 200px;
+  margin-right: 20px;
+`;
+
+const SearchBar = styled(Input.Search)`
+  font-size: 1.6rem;
+  position: relative;
+  z-index: 1;
+
+  .ant-input {
+    height: 36px;
+  }
+
+  .ant-input-search-button {
+    height: 36px;
+  }
+`;
+
+const ResultList = styled.ul`
+  width: 100%;
+  max-height: 168px;
+  border: 1px solid ${({ theme }) => theme.color.border.light};
+  position: relative;
+  top: -2px;
+  overflow-y: auto;
+  background-color: ${({ theme }) => theme.color.white};
+`;
+
+const ResultItem = styled.li`
+  font-size: 1.6rem;
+  cursor: pointer;
+  margin: 8px;
+`;
+
+const Poster = styled(Image)`
+  width: 150px;
+  height: 200px;
+  flex-shrink: 0;
+`;
+
+export default React.memo(ExhibitionSearchBar);

--- a/components/organisms/ExhibitionSearchBar/index.tsx
+++ b/components/organisms/ExhibitionSearchBar/index.tsx
@@ -6,12 +6,15 @@ import { useState, useRef, useCallback } from 'react';
 import { getErrorMessage, show, hide } from 'utils';
 import { useDebounce } from 'hooks';
 import { reviewAPI } from 'apis';
+import { ValueOf } from 'types/utility';
+import { SubmitData } from 'pages/reviews/create';
 
 interface ExhibitionSearchBarProps {
   query: {
     name?: string;
     thumbnail?: string;
   };
+  onExhibitionChange: (key: string, value: ValueOf<SubmitData>) => void;
 }
 
 interface SearchResult {
@@ -20,13 +23,13 @@ interface SearchResult {
   thumbnail: string;
 }
 
-const ExhibitionSearchBar = ({ query }: ExhibitionSearchBarProps) => {
+const ExhibitionSearchBar = ({ query, onExhibitionChange }: ExhibitionSearchBarProps) => {
   const [searchWord, setSearchWord] = useState('');
   const [exhibitionName, setExhibitionName] = useState((query.name as string) || '');
   const [posterImage, setPosterImage] = useState(
     query.thumbnail || DEFAULT_IMAGE.EXHIBITION_THUMBNAIL,
   );
-  const [searchResults, setSearchResults] = useState<SearchResult[]>(); //
+  const [searchResults, setSearchResults] = useState<SearchResult[]>();
   const resultList = useRef<HTMLUListElement>(null);
 
   const handleSearch = useCallback(async () => {
@@ -67,9 +70,9 @@ const ExhibitionSearchBar = ({ query }: ExhibitionSearchBarProps) => {
             <ResultItem
               key={exhibitionId}
               onClick={() => {
-                // submitData.current['exhibitionId'] = exhibitionId;
-                setPosterImage(thumbnail);
+                onExhibitionChange('exhibitionId', exhibitionId);
                 setExhibitionName(name);
+                setPosterImage(thumbnail);
                 resultList.current && hide(resultList.current);
               }}
             >

--- a/components/organisms/ReviewDetail/index.tsx
+++ b/components/organisms/ReviewDetail/index.tsx
@@ -72,12 +72,14 @@ const ReviewDetail = ({ reviewDetail, commentCount, onDeleteButtonClick }: Revie
             createdDate={createdAt}
             userId={userId}
           />
-          {isEdited && <S.ReviewDetailEdited>수정됨</S.ReviewDetailEdited>}
-          {isPublic ? (
-            <S.ReviewDetailPublic>전체 공개</S.ReviewDetailPublic>
-          ) : (
-            <S.ReviewDetailPublic>비공개</S.ReviewDetailPublic>
-          )}
+          <S.ReviewStateContainer>
+            {isEdited && <S.ReviewDetailEdited>수정됨</S.ReviewDetailEdited>}
+            {isPublic ? (
+              <S.ReviewDetailPublic>전체 공개</S.ReviewDetailPublic>
+            ) : (
+              <S.ReviewDetailPublic>비공개</S.ReviewDetailPublic>
+            )}
+          </S.ReviewStateContainer>
         </S.ReviewInfoContainer>
       </S.ReviewDetailHeader>
 

--- a/components/organisms/ReviewDetail/style.ts
+++ b/components/organisms/ReviewDetail/style.ts
@@ -8,9 +8,16 @@ export const ReviewDetailHeader = styled.div`
   margin-bottom: 20px;
 `;
 
+export const ReviewStateContainer = styled.div`
+  display: flex;
+`;
+
 export const ReviewDetailEdited = styled.span`
+  position: relative;
   color: ${({ theme }) => theme.color.font.light};
   font-size: 1.5rem;
+  bottom: -23px;
+  margin-right: 14px;
 `;
 
 export const ReviewDetailPublic = styled.span`

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -9,3 +9,4 @@ export { default as CommentWrite } from './CommentWrite';
 export { default as CommentList } from './CommentList';
 export { default as CommentUtils } from './CommentUtils';
 export { default as ReplyUtils } from './ReplyUtils';
+export { default as ExhibitionSearchBar } from './ExhibitionSearchBar';

--- a/pages/reviews/create/index.tsx
+++ b/pages/reviews/create/index.tsx
@@ -56,9 +56,10 @@ const ReviewCreatePage = () => {
       return;
     }
 
-    if (!isLoading && validateReviewEditForm(submitData.current)) {
+    const data = submitData.current;
+    if (!isLoading && validateReviewEditForm(data)) {
       setIsLoading(true);
-      let formData = convertObjectToFormData('data', submitData.current);
+      let formData = convertObjectToFormData('data', data);
       formData = convertFilesToFormData('files', files, formData);
       try {
         await reviewAPI.createReview(formData);

--- a/pages/reviews/create/index.tsx
+++ b/pages/reviews/create/index.tsx
@@ -86,7 +86,7 @@ const ReviewCreatePage = () => {
       <Section>
         <ReviewEditForm layout="vertical">
           <FormItem label="다녀 온 전시회">
-            <ExhibitionSearchBar query={query} onExhibitionChange={handleChange} />
+            <ExhibitionSearchBar prevData={query} onExhibitionChange={handleChange} />
           </FormItem>
           <FormItem label="다녀 온 날짜">
             <DateInput

--- a/pages/reviews/update/[id]/index.tsx
+++ b/pages/reviews/update/[id]/index.tsx
@@ -52,6 +52,8 @@ const ReviewUpdatePage = () => {
         photos,
       } = response.data.data;
 
+      console.log(date);
+
       submitData.current = {
         exhibitionId,
         date,

--- a/utils/validation/index.ts
+++ b/utils/validation/index.ts
@@ -38,7 +38,7 @@ export const validateReviewEditForm = (submitData: SubmitData) => {
     message.error('다녀온 날짜를 입력해주세요.');
     return isValidateComplete;
   }
-  if (new Date(date) > new Date()) {
+  if (new Date(date as string) > new Date()) {
     message.error('다녀온 날짜는 오늘 이후일 수 없습니다.');
     return isValidateComplete;
   }
@@ -50,7 +50,7 @@ export const validateReviewEditForm = (submitData: SubmitData) => {
     message.error('후기 내용을 입력해주세요.');
     return isValidateComplete;
   }
-  if (content.length > 1000) {
+  if ((content as string).length > 1000) {
     message.error('내용은 1000자 이하로 작성해주세요.');
     return isValidateComplete;
   }


### PR DESCRIPTION
# 작업 내용 (TODO)
후기 작성 및 수정 페이지를 리팩토링했습니다. 
작업 내용은 아래와 같습니다. 

- [x] 재사용을 위해 ExhibitionSearchBar 컴포넌트를 분리
- [x] 후기 수정 페이지에 SWR 및 mutate 적용
- [x] ReviewDetail에서 '수정됨' 텍스트가 중앙으로 오는 버그 수정

@dar-jeeling 확인해주시기 바랍니다. 
https://github.com/prgrms-web-devcourse/Team-BackFro-ArtZip-FE/commit/990e76fa96c6cba7070c65513dfb948d4c35a7d0

close #284
