### PR TITLE
hotfix: 시간 함수 버그 수정 

### DIFF
--- a/utils/displayedAt/index.ts
+++ b/utils/displayedAt/index.ts
@@ -1,6 +1,6 @@
 export const displayDate = (createdAt: string) => {
   const now = new Date();
-  const offset = now.getTimezoneOffset() * 60 * 1000; // KST와 UCT의 차이를 밀리초로 계산
+  const offset = now.getTimezoneOffset() * 60 * 1000; // KST와 UTC의 차이를 밀리초로 계산
   const milliSeconds = now.getTime() + offset - new Date(createdAt).getTime();
 
   const seconds = milliSeconds / 1000;

--- a/utils/displayedAt/index.ts
+++ b/utils/displayedAt/index.ts
@@ -1,5 +1,8 @@
 export const displayDate = (createdAt: string) => {
-  const milliSeconds = new Date().getTime() - new Date(createdAt).getTime();
+  const now = new Date();
+  const offset = now.getTimezoneOffset() * 60 * 1000; // KST와 UCT의 차이를 밀리초로 계산
+  const milliSeconds = now.getTime() + offset - new Date(createdAt).getTime();
+
   const seconds = milliSeconds / 1000;
   if (seconds < 60) {
     return `방금 전`;


### PR DESCRIPTION
# 작업 내용 (TODO)

커뮤니티 페이지, 후기 상세 페이지에서 사용하는 
displayDate 함수의 버그를 수정했습니다. 

- [x] displayDate 함수 버그 수정 

## 문제점
방금 작성한 후기임에도 9시간 전이라고 표시됨 

![image](https://user-images.githubusercontent.com/80658269/191721122-9e841dc2-fb63-43c5-8511-e496038feb1c.png)

## 원인

서버에서 받는 createdAt은 UTC 기준이고, 
클라이언트의 new Date() 값은 KST 기준이라서 차이가 발생

## 해결안
KST - 9시간 = UTC
9시간의 차이를 고려하여 displayDate 함수의 계산 로직 수정 

## 핵심 정리 
- new Date()는 KST 기준이다. 
- KST와 UTC는 9시간의 차이가 난다. 
- Date.getTimezoneOffset()
  : UTC와 로컬 시간과의 차이를 분 단위로 반환한다. 

## 논의하고 싶은 부분

Date 객체의 다른 메소드를 사용하면 더 좋은 해결안이 있을 거라고 생각합니다.
그러나 서버에서 받는 createdAt의 문자열 형식으로 인해 
살짝 꼬였는지 의도한대로 되지는 않더군요. 
버그를 고치는 것이 우선이므로 지금은 이 정도로 하겠습니다. 

close #288
