### PR TITLE
hotfix: 유저 페이지 무한 로딩 버그 수정

### DIFF
--- a/components/atoms/Spinner/index.tsx
+++ b/components/atoms/Spinner/index.tsx
@@ -3,13 +3,14 @@ import { CSSProperties } from 'react';
 
 interface SpinnerProps {
   size?: 'small' | 'default' | 'large';
+  height?: string;
   style?: CSSProperties;
 }
 
-const Spinner = ({ size = 'large', style }: SpinnerProps) => {
+const Spinner = ({ size = 'large', height = '100vh', style }: SpinnerProps) => {
   const spinStyle = {
     display: 'block',
-    height: '100vh',
+    height,
     ...style,
   };
   return <Spin size={size} style={spinStyle} />;

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 import { Tabs, Image, Pagination } from 'antd';
 import { ReviewCard, ExhibitionCard, SideNavigation } from 'components/molecules';
 import { userAPI } from 'apis';
-import { CSSProperties, useEffect, useState } from 'react';
+import { CSSProperties, useEffect, useRef, useState } from 'react';
 import { ReviewCardProps, ExhibitionProps } from 'types/model';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
@@ -14,6 +14,7 @@ interface UserActivity<T> {
   currentPage: number;
   pageSize: number;
   totalSize: number;
+  isLoaded: boolean;
 }
 
 const initialReview = {
@@ -21,6 +22,7 @@ const initialReview = {
   currentPage: 1,
   pageSize: 4,
   totalSize: 0,
+  isLoaded: false,
 };
 
 const initialExhibition = {
@@ -28,6 +30,7 @@ const initialExhibition = {
   currentPage: 1,
   pageSize: 8,
   totalSize: 0,
+  isLoaded: false,
 };
 
 const UserPage = () => {
@@ -66,30 +69,47 @@ const UserPage = () => {
 
   const handleMyReviewChange = async (page: number) => {
     if (userInfo) {
+      setMyReview({
+        ...myReview,
+        isLoaded: false,
+      });
+
       const { data } = await userAPI.getMyReview(userInfo.userId, page - 1, myReview.pageSize);
 
       setMyReview({
         ...myReview,
         payload: data.data.content,
         currentPage: page,
+        isLoaded: true,
       });
     }
   };
 
   const handleLikedReviewChange = async (page: number) => {
     if (userInfo) {
+      setLikedReview({
+        ...likedReview,
+        isLoaded: false,
+      });
+
       const { data } = await userAPI.getLikedReview(userInfo.userId, page - 1, myReview.pageSize);
 
       setLikedReview({
         ...likedReview,
         payload: data.data.content,
         currentPage: page,
+        isLoaded: true,
       });
     }
   };
 
   const handleLikedExhibitionChange = async (page: number) => {
     if (userInfo) {
+      setLikedExhibition({
+        ...likedExhibition,
+        isLoaded: false,
+      });
+
       const { data } = await userAPI.getLikedExhibition(
         userInfo.userId,
         page - 1,
@@ -100,6 +120,7 @@ const UserPage = () => {
         ...likedExhibition,
         payload: data.data.content,
         currentPage: page,
+        isLoaded: true,
       });
     }
   };
@@ -128,7 +149,7 @@ const UserPage = () => {
       <TabCardContainer type="card" tabPosition="top" centered onTabClick={handleTabClick}>
         <Tab tab={`작성한 후기 (${reviewCount})`} key="MY_REVIEW">
           <ReviewContainer>
-            {myReview.payload.length ? (
+            {myReview.isLoaded ? (
               myReview.payload?.map((review) => (
                 <ReviewCard
                   key={review.reviewId}
@@ -160,7 +181,7 @@ const UserPage = () => {
         </Tab>
         <Tab tab={`좋아하는 후기 (${reviewLikeCount})`} key="LIKED_REVIEW">
           <ReviewContainer>
-            {likedReview.payload.length ? (
+            {likedReview.isLoaded ? (
               likedReview.payload.map((review) => (
                 <ReviewCard
                   key={review.reviewId}
@@ -192,7 +213,7 @@ const UserPage = () => {
         </Tab>
         <Tab tab={`좋아하는 전시회 (${exhibitionLikeCount})`} key="LIKED_EXHIBITION">
           <ExhibitionContainer>
-            {likedExhibition.payload.length ? (
+            {likedExhibition.isLoaded ? (
               likedExhibition.payload.map((exhibition) => (
                 <ExhibitionCard
                   key={exhibition.exhibitionId}

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -43,27 +43,31 @@ const UserPage = () => {
   const [likedExhibition, setLikedExhibition] = useState<UserActivity<Required<ExhibitionProps>>>({
     ...initialExhibition,
   });
+  const currentTab = useRef('');
 
   useEffect(() => {
     userInfo && handleTabClick('MY_REVIEW');
   }, [userInfo]);
 
   const handleTabClick = (tabName: string) => {
-    switch (tabName) {
-      case 'MY_REVIEW': {
-        handleMyReviewChange(myReview.currentPage);
-        return;
+    if (currentTab.current !== tabName) {
+      currentTab.current = tabName;
+      switch (tabName) {
+        case 'MY_REVIEW': {
+          handleMyReviewChange(myReview.currentPage);
+          return;
+        }
+        case 'LIKED_REVIEW': {
+          handleLikedReviewChange(likedReview.currentPage);
+          return;
+        }
+        case 'LIKED_EXHIBITION': {
+          handleLikedExhibitionChange(likedExhibition.currentPage);
+          return;
+        }
+        default:
+          console.error('Invalid key');
       }
-      case 'LIKED_REVIEW': {
-        handleLikedReviewChange(likedReview.currentPage);
-        return;
-      }
-      case 'LIKED_EXHIBITION': {
-        handleLikedExhibitionChange(likedExhibition.currentPage);
-        return;
-      }
-      default:
-        console.error('Invalid key');
     }
   };
 

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -33,11 +33,11 @@ const initialExhibition = {
 
 interface Tab {
   name: '' | 'MY_REVIEW' | 'LIKED_REVIEW' | 'LIKED_EXHIBITION';
-  state: UserActivity<ReviewCardProps | Required<ExhibitionProps>>;
-  setState:
+  cardList: UserActivity<ReviewCardProps | Required<ExhibitionProps>>;
+  setCardList:
     | Dispatch<SetStateAction<UserActivity<ReviewCardProps>>>
     | Dispatch<SetStateAction<UserActivity<Required<ExhibitionProps>>>>;
-  fetcher: (userId: number, page: number, size: number) => Promise<AxiosResponse>;
+  fetchCardList: (userId: number, page: number, size: number) => Promise<AxiosResponse>;
 }
 
 const UserPage = () => {
@@ -52,9 +52,9 @@ const UserPage = () => {
   });
   const tab = useRef<Tab>({
     name: '',
-    state: myReview,
-    setState: setMyReview,
-    fetcher: userAPI.getMyReview,
+    cardList: myReview,
+    setCardList: setMyReview,
+    fetchCardList: userAPI.getMyReview,
   });
   const [isLoaded, setIsLoaded] = useState(false);
 
@@ -68,45 +68,45 @@ const UserPage = () => {
         case 'MY_REVIEW': {
           tab.current = {
             name: tabName,
-            state: myReview,
-            setState: setMyReview,
-            fetcher: userAPI.getMyReview,
+            cardList: myReview,
+            setCardList: setMyReview,
+            fetchCardList: userAPI.getMyReview,
           };
           break;
         }
         case 'LIKED_REVIEW': {
           tab.current = {
             name: tabName,
-            state: likedReview,
-            setState: setLikedReview,
-            fetcher: userAPI.getLikedReview,
+            cardList: likedReview,
+            setCardList: setLikedReview,
+            fetchCardList: userAPI.getLikedReview,
           };
           break;
         }
         case 'LIKED_EXHIBITION': {
           tab.current = {
             name: tabName,
-            state: likedExhibition,
-            setState: setLikedExhibition,
-            fetcher: userAPI.getLikedExhibition,
+            cardList: likedExhibition,
+            setCardList: setLikedExhibition,
+            fetchCardList: userAPI.getLikedExhibition,
           };
           break;
         }
         default:
           console.error('Invalid tabName');
       }
-      handleChange(tab.current.state.currentPage);
+      handleChange(tab.current.cardList.currentPage);
     }
   };
 
   const handleChange = async (page: number) => {
     if (userInfo) {
       setIsLoaded(false);
-      const { state, setState, fetcher } = tab.current;
-      const { data } = await fetcher(userInfo.userId, page - 1, state.pageSize);
+      const { cardList, setCardList, fetchCardList } = tab.current;
+      const { data } = await fetchCardList(userInfo.userId, page - 1, cardList.pageSize);
 
-      setState({
-        ...state,
+      setCardList({
+        ...cardList,
         payload: data.data.content,
         currentPage: page,
       });

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -108,13 +108,14 @@ const UserPage = () => {
       setState({
         ...state,
         payload: data.data.content,
+        currentPage: page,
       });
       setIsLoaded(true);
     }
   };
 
   if (!userInfo) {
-    return <Spinner size="large" />;
+    return <Spinner />;
   }
 
   const {

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -171,7 +171,7 @@ const UserPage = () => {
                 />
               ))
             ) : (
-              <Spinner />
+              <Spinner height="50vh" />
             )}
           </ReviewContainer>
           <Pagination
@@ -203,7 +203,7 @@ const UserPage = () => {
                 />
               ))
             ) : (
-              <Spinner />
+              <Spinner height="50vh" />
             )}
           </ReviewContainer>
           <Pagination
@@ -232,7 +232,7 @@ const UserPage = () => {
                 />
               ))
             ) : (
-              <Spinner />
+              <Spinner height="50vh" />
             )}
           </ExhibitionContainer>
           <Pagination


### PR DESCRIPTION
# 작업 내용 (TODO)

유저 페이지에서 작성한 후기 데이터가 없을 때,
무한 로딩이 걸리는 버그를 수정했습니다. 
그 외 불필요한 API 호출 방지, 함수 리팩토링을 수행했습니다. 

- [x] 무한 로딩 버그 수정
- [x] API 중복 호출 방지 (동일한 탭 클릭 시)
- [x] 중복된 함수들을 하나의 함수로 통합하여 코드량 감소

close #295
