### PR TITLE
refactor: ExhibitionCard와 ReviewCard의 props 수정

### DIFF
--- a/components/molecules/ExhibitionCard/index.tsx
+++ b/components/molecules/ExhibitionCard/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Card } from 'antd';
 import { HeartFilled, HeartOutlined, MessageOutlined } from '@ant-design/icons';
 import * as S from './style';
@@ -8,19 +8,19 @@ import { displayDday, displayFormattedDate } from 'utils';
 import Image from 'next/image';
 import DEFAULT_IMAGE from 'constants/defaultImage';
 
-const { Meta } = Card;
+interface ExhibitionCardProps {
+  data: Required<ExhibitionProps>;
+}
 
-const ExhibitionCard = ({
-  exhibitionId,
-  name,
-  thumbnail,
-  startDate,
-  endDate,
-  likeCount,
-  reviewCount,
-  isLiked,
-}: Required<ExhibitionProps>) => {
+const ExhibitionCard = ({ data }: ExhibitionCardProps) => {
   const [isHover, setIsHover] = useState(false);
+
+  if (!data) {
+    return null;
+  }
+  const { exhibitionId, name, thumbnail, startDate, endDate, likeCount, reviewCount, isLiked } =
+    data;
+
   const dDay = displayDday(startDate);
   const mouseHover = () => setIsHover((isHover) => !isHover);
 

--- a/components/molecules/ReviewCard/index.tsx
+++ b/components/molecules/ReviewCard/index.tsx
@@ -7,34 +7,41 @@ import { PhotoProps } from 'types/model';
 import DEFAULT_IMAGE from 'constants/defaultImage';
 
 interface ReviewCardProps {
-  reviewId: number;
+  data: {
+    reviewId: number;
+    user: {
+      userId: number;
+      nickname: string;
+      profileImage: string;
+    };
+    title: string;
+    content: string;
+    createdAt: string;
+    likeCount: number;
+    commentCount: number;
+    photos: PhotoProps[] | null;
+  };
   thumbnail: string;
-  title: string;
-  content: string;
-  createdAt: string;
-  userId: number;
-  profileImage: string;
-  nickname: string;
-  likeCount: number;
-  commentCount: number;
-  photo: PhotoProps[] | null;
 }
 
-const ReviewCard = ({
-  reviewId,
-  thumbnail,
-  title,
-  content,
-  createdAt,
-  userId,
-  profileImage,
-  nickname,
-  likeCount,
-  commentCount,
-  photo,
-}: ReviewCardProps) => {
+const ReviewCard = ({ data, thumbnail }: ReviewCardProps) => {
   const [isHover, setIsHover] = useState(false);
   const mouseHover = () => setIsHover((isHover) => !isHover);
+
+  if (!data) {
+    return null;
+  }
+
+  const {
+    reviewId,
+    title,
+    content,
+    createdAt,
+    likeCount,
+    commentCount,
+    photos,
+    user: { userId, nickname, profileImage },
+  } = data;
 
   return (
     <Link href={`/reviews/detail/${reviewId}`}>
@@ -42,7 +49,7 @@ const ReviewCard = ({
         <S.ReviewCard>
           <S.PhotoWrapper onMouseEnter={mouseHover} onMouseLeave={mouseHover}>
             <S.Photo
-              src={photo && photo.length > 0 ? photo[0].path : thumbnail}
+              src={photos && photos.length > 0 ? photos[0].path : thumbnail}
               alt="review photo"
               layout="fixed"
               width={110}

--- a/components/organisms/Swiper/index.tsx
+++ b/components/organisms/Swiper/index.tsx
@@ -1,7 +1,7 @@
 import { Swiper, SwiperSlide } from 'swiper/react';
 import SwiperCore, { Navigation, Autoplay } from 'swiper';
 import * as S from './style';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ExhibitionProps } from 'types/model';
 import { ExhibitionCard } from 'components/molecules';
 import useWindowSize from 'hooks/useWindowSize';
@@ -10,7 +10,7 @@ import theme from 'styles/global/theme';
 SwiperCore.use([Navigation, Autoplay]);
 
 interface SwiperProps {
-  items: ExhibitionProps[];
+  items: Required<ExhibitionProps>[];
 }
 
 const checkIsMobile = (windowWidthSize: number) => {
@@ -46,16 +46,7 @@ const SwiperWrapper = ({ items }: SwiperProps) => {
         >
           {items.map((item) => (
             <SwiperSlide key={item.exhibitionId} className="MyBanner__slideItem">
-              <ExhibitionCard
-                exhibitionId={item.exhibitionId}
-                name={item.name}
-                thumbnail={item.thumbnail}
-                startDate={item.startDate!}
-                endDate={item.endDate!}
-                likeCount={item.likeCount!}
-                reviewCount={item.reviewCount!}
-                isLiked={item.isLiked!}
-              />
+              <ExhibitionCard data={item} />
             </SwiperSlide>
           ))}
         </Swiper>

--- a/pages/exhibitions/custom/index.tsx
+++ b/pages/exhibitions/custom/index.tsx
@@ -11,7 +11,7 @@ import styled from '@emotion/styled';
 //exhibitions/custom
 const ExhibitionCustom: NextPage = () => {
   const [currentPage, setCurrentPage] = useState(0);
-  const [exhibitions, setExhibitions] = useState<ExhibitionProps[]>([]);
+  const [exhibitions, setExhibitions] = useState<Required<ExhibitionProps>[]>([]);
   const [selectedArea, setSelectedArea] = useState<{ id: number; value: string; name: string }[]>(
     [],
   );
@@ -74,17 +74,7 @@ const ExhibitionCustom: NextPage = () => {
       <S.ExhibitionsCustomContent>
         {exhibitions.length > 0 ? (
           exhibitions.map((exhibition) => (
-            <ExhibitionCard
-              exhibitionId={exhibition.exhibitionId}
-              key={exhibition.exhibitionId}
-              name={exhibition.name}
-              thumbnail={exhibition.thumbnail}
-              startDate={exhibition.startDate!}
-              endDate={exhibition.endDate!}
-              likeCount={exhibition.likeCount!}
-              reviewCount={exhibition.reviewCount!}
-              isLiked={exhibition.isLiked!}
-            />
+            <ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
           ))
         ) : (
           <div>

--- a/pages/exhibitions/detail/[id]/index.tsx
+++ b/pages/exhibitions/detail/[id]/index.tsx
@@ -63,18 +63,9 @@ const ExhibitionDetailPage = () => {
               {exhibitionData.reviews.map((review) => (
                 <ReviewCard
                   key={review.reviewId}
-                  reviewId={review.reviewId}
+                  data={review}
                   thumbnail={exhibitionData.thumbnail}
-                  title={review.title}
-                  content={review.content}
-                  createdAt={review.createdAt}
-                  likeCount={review.likeCount}
-                  commentCount={review.commentCount}
-                  photo={review.photos}
-                  userId={review.user.userId}
-                  nickname={review.user.nickname}
-                  profileImage={review.user.profileImage}
-                ></ReviewCard>
+                />
               ))}
             </S.ReviewContainer>
           )}

--- a/pages/exhibitions/more/index.tsx
+++ b/pages/exhibitions/more/index.tsx
@@ -12,7 +12,7 @@ const ExhibitionsMore: NextPage = () => {
   const router = useRouter();
   const { type } = router.query;
   const [currentPage, setCurrentPage] = useState(0);
-  const [exhibitions, setExhibitions] = useState<ExhibitionProps[]>([]);
+  const [exhibitions, setExhibitions] = useState<Required<ExhibitionProps>[]>([]);
   const [total, setTotal] = useState(0);
 
   useEffect(() => {
@@ -50,17 +50,7 @@ const ExhibitionsMore: NextPage = () => {
       </div>
       <S.ExhibitionsMoreContent>
         {exhibitions.map((exhibition) => (
-          <ExhibitionCard
-            exhibitionId={exhibition.exhibitionId}
-            key={exhibition.exhibitionId}
-            name={exhibition.name}
-            thumbnail={exhibition.thumbnail}
-            startDate={exhibition.startDate!}
-            endDate={exhibition.endDate!}
-            likeCount={exhibition.likeCount!}
-            reviewCount={exhibition.reviewCount!}
-            isLiked={exhibition.isLiked!}
-          />
+          <ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
         ))}
       </S.ExhibitionsMoreContent>
       <Pagination

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,8 +11,8 @@ import { exhibitionAPI } from 'apis';
 import { ExhibitionProps } from 'types/model';
 
 interface HomeProps {
-  upcomingExhibitions: ExhibitionProps[];
-  mostLikeExhibitions: ExhibitionProps[];
+  upcomingExhibitions: Required<ExhibitionProps>[];
+  mostLikeExhibitions: Required<ExhibitionProps>[];
 }
 const Home: NextPage<HomeProps> = ({ upcomingExhibitions, mostLikeExhibitions }) => {
   return (

--- a/pages/search-result/[exhibition]/index.tsx
+++ b/pages/search-result/[exhibition]/index.tsx
@@ -13,7 +13,7 @@ const SearchResultPage: NextPage = () => {
   const router = useRouter();
   const [exhibition, setExhibition] = useState('');
   const [currentPage, setCurrentPage] = useState(0);
-  const [exhibitions, setExhibitions] = useState<ExhibitionProps[]>([]);
+  const [exhibitions, setExhibitions] = useState<Required<ExhibitionProps>[]>([]);
   const [total, setTotal] = useState(0);
 
   useEffect(() => {
@@ -43,17 +43,7 @@ const SearchResultPage: NextPage = () => {
       <S.SearchResultContents>
         {exhibitions.length > 0 ? (
           exhibitions.map((exhibition) => (
-            <ExhibitionCard
-              exhibitionId={exhibition.exhibitionId}
-              key={exhibition.exhibitionId}
-              name={exhibition.name}
-              thumbnail={exhibition.thumbnail}
-              startDate={exhibition.startDate!}
-              endDate={exhibition.endDate!}
-              likeCount={exhibition.likeCount!}
-              reviewCount={exhibition.reviewCount!}
-              isLiked={exhibition.isLiked!}
-            />
+            <ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
           ))
         ) : (
           <div>

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -172,17 +172,7 @@ const UserPage = () => {
           <ExhibitionContainer>
             {likedExhibition.payload.length ? (
               likedExhibition.payload.map((exhibition) => (
-                <ExhibitionCard
-                  key={exhibition.exhibitionId}
-                  exhibitionId={exhibition.exhibitionId}
-                  name={exhibition.name}
-                  thumbnail={exhibition.thumbnail}
-                  startDate={exhibition.startDate}
-                  endDate={exhibition.endDate}
-                  likeCount={exhibition.likeCount}
-                  reviewCount={exhibition.reviewCount}
-                  isLiked={exhibition.isLiked}
-                />
+                <ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
               ))
             ) : (
               <Spinner />

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -128,26 +128,13 @@ const UserPage = () => {
       <TabCardContainer type="card" tabPosition="top" centered onTabClick={handleTabClick}>
         <Tab tab={`작성한 후기 (${reviewCount})`} key="MY_REVIEW">
           <ReviewContainer>
-            {myReview.payload.length ? (
-              myReview.payload?.map((review) => (
-                <ReviewCard
-                  key={review.reviewId}
-                  reviewId={review.reviewId}
-                  title={review.title}
-                  content={review.content}
-                  thumbnail={review.exhibition.thumbnail}
-                  createdAt={review.createdAt}
-                  likeCount={review.likeCount}
-                  commentCount={review.commentCount}
-                  photo={review.photos}
-                  userId={review.user.userId}
-                  nickname={review.user.nickname}
-                  profileImage={review.user.profileImage}
-                />
-              ))
-            ) : (
-              <Spinner />
-            )}
+            {myReview.payload?.map((review) => (
+              <ReviewCard
+                key={review.reviewId}
+                data={review}
+                thumbnail={review.exhibition.thumbnail}
+              />
+            ))}
           </ReviewContainer>
           <Pagination
             defaultCurrent={myReview.currentPage}
@@ -164,17 +151,8 @@ const UserPage = () => {
               likedReview.payload.map((review) => (
                 <ReviewCard
                   key={review.reviewId}
-                  reviewId={review.reviewId}
-                  title={review.title}
-                  content={review.content}
+                  data={review}
                   thumbnail={review.exhibition.thumbnail}
-                  createdAt={review.createdAt}
-                  likeCount={review.likeCount}
-                  commentCount={review.commentCount}
-                  photo={review.photos}
-                  userId={review.user.userId}
-                  nickname={review.user.nickname}
-                  profileImage={review.user.profileImage}
                 />
               ))
             ) : (

--- a/types/model.ts
+++ b/types/model.ts
@@ -1,5 +1,4 @@
 import { ReviewSingleReadData } from './apis/review/index';
-import { CSSProperties } from 'react';
 
 export interface ExhibitionProps {
   exhibitionId: number;
@@ -77,6 +76,7 @@ export interface PhotoProps {
 export interface UserAtomProps {
   userId: number | null;
   email: string | null;
-  nicknamae: string | null;
+  nickname: string | null;
   profileImage: string | null;
+  isLoggedIn: boolean;
 }


### PR DESCRIPTION
# 작업 내용 (TODO)

ExhibitionCard와 ReviewCard의 props를 수정했습니다. 
git 브랜치가 조금 꼬여서 새로운 브랜치를 만들어 PR합니다.
충돌은 해결했고, 이전과 변경사항은 동일합니다.

## 문제점
ExhibitionCard와 ReviewCard 사용 시 아래와 같이 
데이터를 하나씩 주입해주는 방식을 취하고 있습니다. 

```tsx
<ExhibitionCard
  exhibitionId={exhibition.exhibitionId}
  key={exhibition.exhibitionId}
  name={exhibition.name}
  thumbnail={exhibition.thumbnail}
  startDate={exhibition.startDate!}
  endDate={exhibition.endDate!}
  likeCount={exhibition.likeCount!}
  reviewCount={exhibition.reviewCount!}
  isLiked={exhibition.isLiked!}
/>
```

컴포넌트를 사용하는 입장에서 많이 불편한 방식입니다. 
(멘토님께서 중간 피드백에서 지적해주신 내용입니다)

아래와 같이 데이터를 한꺼번에 넘기는 방식으로 리팩토링했습니다. 

```tsx
<ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
```

전달된 데이터는 해당 컴포넌트 내부에서 디스트럭처링합니다. 

```tsx
// exhibitionCard
  const { exhibitionId, name, thumbnail, startDate, endDate, likeCount, reviewCount, isLiked } =
    data;
```

- [x] ExhibitionCard의 props 수정
- [x] ReviewCard의 props 수정

# 논의하고 싶은 부분

@Hyevvy  @yunjjeongjo 
두 분께서 작성하셨던 코드를 수정한 것입니다. 
그러므로 이번 PR은 리뷰를 꼭 부탁합니다. 
피드백 반영하겠습니다. 

수정 후, 로컬 서버에서 정상 동작하는 것을 확인했습니다. 
그래도 브랜치에 한 번씩 들어오셔서 확인해주시면 감사하겠습니다. 

close #259
