### PR TITLE
refactor: 유저페이지의 컴포넌트 추출 및 SWR 적용

### DIFF
--- a/components/molecules/SideNavigation/index.tsx
+++ b/components/molecules/SideNavigation/index.tsx
@@ -2,8 +2,6 @@ import styled from '@emotion/styled';
 import { Button } from 'antd';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useRecoilValue } from 'recoil';
-import { userAtom } from 'states';
 
 interface SideNavigationProps {
   paths: {
@@ -13,12 +11,9 @@ interface SideNavigationProps {
 }
 
 const SideNavigation = ({ paths }: SideNavigationProps) => {
-  const { userId } = useRecoilValue(userAtom);
-  const { query, asPath } = useRouter();
+  const { asPath } = useRouter();
 
-  const isMyPage = String(userId) === query.id;
-
-  return isMyPage ? (
+  return (
     <Navigation>
       {paths.map(({ href, pageName }, i) => (
         <Link href={href} key={i}>
@@ -30,7 +25,7 @@ const SideNavigation = ({ paths }: SideNavigationProps) => {
         </Link>
       ))}
     </Navigation>
-  ) : null;
+  );
 };
 
 const Navigation = styled.nav`

--- a/components/molecules/UserProfileCard/index.tsx
+++ b/components/molecules/UserProfileCard/index.tsx
@@ -1,0 +1,55 @@
+import { CSSProperties } from 'react';
+import styled from '@emotion/styled';
+import { Image } from 'antd';
+import DEFAULT_IMAGE from 'constants/defaultImage';
+
+interface UserProfileCardProps {
+  data: {
+    email: string;
+    nickname: string;
+    profileImage: string;
+  };
+  cardStyle?: CSSProperties;
+  photoStyle?: CSSProperties;
+}
+
+const UserProfileCard = ({ data, cardStyle, photoStyle }: UserProfileCardProps) => {
+  const { email, nickname, profileImage } = data;
+  return (
+    <ProfileContainer style={cardStyle}>
+      <ProfileImage
+        src={profileImage || DEFAULT_IMAGE.USER_PROFILE}
+        alt="프로필 이미지"
+        style={photoStyle}
+      />
+      <UserNickname>{nickname}</UserNickname>
+      <UserEmail>{email}</UserEmail>
+    </ProfileContainer>
+  );
+};
+
+const ProfileContainer = styled.div`
+  display: inline-flex;
+  flex-direction: column;
+  padding: 20px;
+  background-color: transparent;
+`;
+
+const ProfileImage = styled(Image)`
+  width: 160px;
+  height: 160px;
+  border-radius: 50%;
+  margin-bottom: 20px;
+`;
+
+const UserNickname = styled.span`
+  font-size: 2.4rem;
+  font-weight: 700;
+`;
+
+const UserEmail = styled.span`
+  font-size: 1.8rem;
+  color: ${({ theme }) => theme.color.font.dark};
+`;
+
+export default UserProfileCard;

--- a/components/molecules/UserProfileCard/index.tsx
+++ b/components/molecules/UserProfileCard/index.tsx
@@ -2,19 +2,23 @@ import { CSSProperties } from 'react';
 import styled from '@emotion/styled';
 import { Image } from 'antd';
 import DEFAULT_IMAGE from 'constants/defaultImage';
+import useSWR from 'swr';
+import { Spinner } from 'components/atoms';
 
 interface UserProfileCardProps {
-  data: {
-    email: string;
-    nickname: string;
-    profileImage: string;
-  };
+  userId: string;
   cardStyle?: CSSProperties;
   photoStyle?: CSSProperties;
 }
 
-const UserProfileCard = ({ data, cardStyle, photoStyle }: UserProfileCardProps) => {
-  const { email, nickname, profileImage } = data;
+const UserProfileCard = ({ userId, cardStyle, photoStyle }: UserProfileCardProps) => {
+  const { data: userInfo } = useSWR(`api/v1/users/${userId}/info`);
+
+  if (!userInfo) {
+    return <Spinner />;
+  }
+
+  const { email, nickname, profileImage } = userInfo;
   return (
     <ProfileContainer style={cardStyle}>
       <ProfileImage

--- a/components/molecules/index.ts
+++ b/components/molecules/index.ts
@@ -9,3 +9,4 @@ export { default as ExhibitionInfo } from './ExhibitionInfo';
 export { default as ReviewExhibitionInfo } from './ReviewExhibitionInfo';
 export { default as ScrollButton } from './ScrollButton';
 export { default as SideNavigation } from './SideNavigation';
+export { default as UserProfileCard } from './UserProfileCard';

--- a/components/organisms/UserActivityCardList/index.tsx
+++ b/components/organisms/UserActivityCardList/index.tsx
@@ -1,0 +1,227 @@
+import styled from '@emotion/styled';
+import { Tabs, Pagination } from 'antd';
+import { ReviewCard, ExhibitionCard } from 'components/molecules';
+import { CSSProperties, Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
+import { ReviewCardProps, ExhibitionProps } from 'types/model';
+import { Spinner } from 'components/atoms';
+import { AxiosResponse } from 'axios';
+import { userAPI } from 'apis';
+import useSWR from 'swr';
+
+interface UserActivity<T> {
+  payload: T[];
+  currentPage: number;
+  pageSize: number;
+  totalSize: number;
+}
+
+const initialData = {
+  payload: [],
+  currentPage: 1,
+  pageSize: 4,
+  totalSize: 0,
+};
+
+interface Tab {
+  name: '' | 'MY_REVIEW' | 'LIKED_REVIEW' | 'LIKED_EXHIBITION';
+  cardList: UserActivity<ReviewCardProps | Required<ExhibitionProps>>;
+  setCardList:
+    | Dispatch<SetStateAction<UserActivity<ReviewCardProps>>>
+    | Dispatch<SetStateAction<UserActivity<Required<ExhibitionProps>>>>;
+  fetchCardList: (userId: number, page: number, size: number) => Promise<AxiosResponse>;
+}
+
+const UserActivityCardList = ({ userId }: { userId: string }) => {
+  const { data: userInfo } = useSWR(`api/v1/users/${userId}/info`);
+  const [myReview, setMyReview] = useState<UserActivity<ReviewCardProps>>({ ...initialData });
+  const [likedReview, setLikedReview] = useState<UserActivity<ReviewCardProps>>({
+    ...initialData,
+  });
+  const [likedExhibition, setLikedExhibition] = useState<UserActivity<Required<ExhibitionProps>>>({
+    ...initialData,
+    pageSize: 8,
+  });
+  const tab = useRef<Tab>({
+    name: '',
+    cardList: myReview,
+    setCardList: setMyReview,
+    fetchCardList: userAPI.getMyReview,
+  });
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  const handleTabClick = (tabName: string) => {
+    if (tab.current.name !== tabName) {
+      switch (tabName) {
+        case 'MY_REVIEW': {
+          tab.current = {
+            name: tabName,
+            cardList: myReview,
+            setCardList: setMyReview,
+            fetchCardList: userAPI.getMyReview,
+          };
+          break;
+        }
+        case 'LIKED_REVIEW': {
+          tab.current = {
+            name: tabName,
+            cardList: likedReview,
+            setCardList: setLikedReview,
+            fetchCardList: userAPI.getLikedReview,
+          };
+          break;
+        }
+        case 'LIKED_EXHIBITION': {
+          tab.current = {
+            name: tabName,
+            cardList: likedExhibition,
+            setCardList: setLikedExhibition,
+            fetchCardList: userAPI.getLikedExhibition,
+          };
+          break;
+        }
+        default:
+          console.error('Invalid tabName');
+      }
+      handleChange(tab.current.cardList.currentPage);
+    }
+  };
+
+  const handleChange = async (page: number) => {
+    if (userInfo) {
+      setIsLoaded(false);
+      const { cardList, setCardList, fetchCardList } = tab.current;
+      const { data } = await fetchCardList(userInfo.userId, page - 1, cardList.pageSize);
+
+      setCardList({
+        ...cardList,
+        payload: data.data.content,
+        currentPage: page,
+      });
+      setIsLoaded(true);
+    }
+  };
+
+  useEffect(() => {
+    userInfo && handleTabClick('MY_REVIEW');
+  }, [userInfo]);
+
+  if (!userInfo) {
+    return <Spinner />;
+  }
+
+  const { reviewCount, reviewLikeCount, exhibitionLikeCount } = userInfo;
+  return (
+    <TabCardContainer type="card" tabPosition="top" centered onTabClick={handleTabClick}>
+      <Tab tab={`작성한 후기 (${reviewCount})`} key="MY_REVIEW">
+        <ReviewContainer>
+          {isLoaded ? (
+            myReview.payload?.map((review) => (
+              <ReviewCard
+                key={review.reviewId}
+                data={review}
+                thumbnail={review.exhibition.thumbnail}
+              />
+            ))
+          ) : (
+            <Spinner height="50vh" />
+          )}
+        </ReviewContainer>
+        <Pagination
+          defaultCurrent={myReview.currentPage}
+          pageSize={myReview.pageSize}
+          total={reviewCount}
+          onChange={handleChange}
+          hideOnSinglePage={true}
+          style={paginationStyle}
+        />
+      </Tab>
+      <Tab tab={`좋아하는 후기 (${reviewLikeCount})`} key="LIKED_REVIEW">
+        <ReviewContainer>
+          {isLoaded ? (
+            likedReview.payload.map((review) => (
+              <ReviewCard
+                key={review.reviewId}
+                data={review}
+                thumbnail={review.exhibition.thumbnail}
+              />
+            ))
+          ) : (
+            <Spinner height="50vh" />
+          )}
+        </ReviewContainer>
+        <Pagination
+          defaultCurrent={likedReview.currentPage}
+          pageSize={likedReview.pageSize}
+          total={reviewLikeCount}
+          onChange={handleChange}
+          hideOnSinglePage={true}
+          style={paginationStyle}
+        />
+      </Tab>
+      <Tab tab={`좋아하는 전시회 (${exhibitionLikeCount})`} key="LIKED_EXHIBITION">
+        <ExhibitionContainer>
+          {isLoaded ? (
+            likedExhibition.payload.map((exhibition) => (
+              <ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
+            ))
+          ) : (
+            <Spinner height="50vh" />
+          )}
+        </ExhibitionContainer>
+        <Pagination
+          defaultCurrent={likedExhibition.currentPage}
+          pageSize={likedExhibition.pageSize}
+          total={userInfo.exhibitionLikeCount}
+          hideOnSinglePage={true}
+          onChange={handleChange}
+          style={paginationStyle}
+        />
+      </Tab>
+    </TabCardContainer>
+  );
+};
+
+const TabCardContainer = styled(Tabs)`
+  margin-top: 30px;
+`;
+
+const Tab = styled(Tabs.TabPane)`
+  text-align: left;
+`;
+
+const ReviewContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  justify-content: center;
+  justify-items: center;
+  gap: 10px;
+  padding: 0 70px 30px 70px;
+
+  @media screen and (max-width: ${({ theme }) => theme.breakPoint.mobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const ExhibitionContainer = styled.div`
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  justify-content: center;
+  justify-items: center;
+  gap: 10px;
+  padding-bottom: 30px;
+
+  @media screen and (max-width: ${({ theme }) => theme.breakPoint.tablet}) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media screen and (max-width: ${({ theme }) => theme.breakPoint.mobile}) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const paginationStyle: CSSProperties = {
+  textAlign: 'center',
+  marginBottom: '24px',
+};
+
+export default UserActivityCardList;

--- a/components/organisms/index.ts
+++ b/components/organisms/index.ts
@@ -10,3 +10,4 @@ export { default as CommentList } from './CommentList';
 export { default as CommentUtils } from './CommentUtils';
 export { default as ReplyUtils } from './ReplyUtils';
 export { default as ExhibitionSearchBar } from './ExhibitionSearchBar';
+export { default as UserActivityCardList } from './UserActivityCardList';

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -1,224 +1,37 @@
 import styled from '@emotion/styled';
-import { Tabs, Pagination } from 'antd';
-import { UserProfileCard, ReviewCard, ExhibitionCard, SideNavigation } from 'components/molecules';
-import { userAPI } from 'apis';
-import { CSSProperties, Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
-import { ReviewCardProps, ExhibitionProps } from 'types/model';
+import { UserProfileCard, SideNavigation } from 'components/molecules';
 import { useRouter } from 'next/router';
-import useSWR from 'swr';
-import { Spinner } from 'components/atoms';
-import { AxiosResponse } from 'axios';
-
-interface UserActivity<T> {
-  payload: T[];
-  currentPage: number;
-  pageSize: number;
-  totalSize: number;
-}
-
-const initialReview = {
-  payload: [],
-  currentPage: 1,
-  pageSize: 4,
-  totalSize: 0,
-};
-
-const initialExhibition = {
-  payload: [],
-  currentPage: 1,
-  pageSize: 8,
-  totalSize: 0,
-};
-
-interface Tab {
-  name: '' | 'MY_REVIEW' | 'LIKED_REVIEW' | 'LIKED_EXHIBITION';
-  cardList: UserActivity<ReviewCardProps | Required<ExhibitionProps>>;
-  setCardList:
-    | Dispatch<SetStateAction<UserActivity<ReviewCardProps>>>
-    | Dispatch<SetStateAction<UserActivity<Required<ExhibitionProps>>>>;
-  fetchCardList: (userId: number, page: number, size: number) => Promise<AxiosResponse>;
-}
+import { UserActivityCardList } from 'components/organisms';
+import { useRecoilValue } from 'recoil';
+import { userAtom } from 'states';
 
 const UserPage = () => {
+  const { userId } = useRecoilValue(userAtom);
   const { id } = useRouter().query;
-  const { data: userInfo } = useSWR(`api/v1/users/${id}/info`);
-  const [myReview, setMyReview] = useState<UserActivity<ReviewCardProps>>({ ...initialReview });
-  const [likedReview, setLikedReview] = useState<UserActivity<ReviewCardProps>>({
-    ...initialReview,
-  });
-  const [likedExhibition, setLikedExhibition] = useState<UserActivity<Required<ExhibitionProps>>>({
-    ...initialExhibition,
-  });
-  const tab = useRef<Tab>({
-    name: '',
-    cardList: myReview,
-    setCardList: setMyReview,
-    fetchCardList: userAPI.getMyReview,
-  });
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  useEffect(() => {
-    userInfo && handleTabClick('MY_REVIEW');
-  }, [userInfo]);
-
-  const handleTabClick = (tabName: string) => {
-    if (tab.current.name !== tabName) {
-      switch (tabName) {
-        case 'MY_REVIEW': {
-          tab.current = {
-            name: tabName,
-            cardList: myReview,
-            setCardList: setMyReview,
-            fetchCardList: userAPI.getMyReview,
-          };
-          break;
-        }
-        case 'LIKED_REVIEW': {
-          tab.current = {
-            name: tabName,
-            cardList: likedReview,
-            setCardList: setLikedReview,
-            fetchCardList: userAPI.getLikedReview,
-          };
-          break;
-        }
-        case 'LIKED_EXHIBITION': {
-          tab.current = {
-            name: tabName,
-            cardList: likedExhibition,
-            setCardList: setLikedExhibition,
-            fetchCardList: userAPI.getLikedExhibition,
-          };
-          break;
-        }
-        default:
-          console.error('Invalid tabName');
-      }
-      handleChange(tab.current.cardList.currentPage);
-    }
-  };
-
-  const handleChange = async (page: number) => {
-    if (userInfo) {
-      setIsLoaded(false);
-      const { cardList, setCardList, fetchCardList } = tab.current;
-      const { data } = await fetchCardList(userInfo.userId, page - 1, cardList.pageSize);
-
-      setCardList({
-        ...cardList,
-        payload: data.data.content,
-        currentPage: page,
-      });
-      setIsLoaded(true);
-    }
-  };
-
-  if (!userInfo) {
-    return <Spinner />;
-  }
-
-  const {
-    userId,
-    profileImage,
-    nickname,
-    email,
-    reviewCount,
-    reviewLikeCount,
-    exhibitionLikeCount,
-  } = userInfo;
+  const isMyPage = String(userId) === id;
 
   return (
     <PageContainer>
-      <UserProfileCard
-        data={{
-          email,
-          nickname,
-          profileImage,
-        }}
-      />
-      <TabCardContainer type="card" tabPosition="top" centered onTabClick={handleTabClick}>
-        <Tab tab={`작성한 후기 (${reviewCount})`} key="MY_REVIEW">
-          <ReviewContainer>
-            {isLoaded ? (
-              myReview.payload?.map((review) => (
-                <ReviewCard
-                  key={review.reviewId}
-                  data={review}
-                  thumbnail={review.exhibition.thumbnail}
-                />
-              ))
-            ) : (
-              <Spinner height="50vh" />
-            )}
-          </ReviewContainer>
-          <Pagination
-            defaultCurrent={myReview.currentPage}
-            pageSize={myReview.pageSize}
-            total={reviewCount}
-            onChange={handleChange}
-            hideOnSinglePage={true}
-            style={paginationStyle}
-          />
-        </Tab>
-        <Tab tab={`좋아하는 후기 (${reviewLikeCount})`} key="LIKED_REVIEW">
-          <ReviewContainer>
-            {isLoaded ? (
-              likedReview.payload.map((review) => (
-                <ReviewCard
-                  key={review.reviewId}
-                  data={review}
-                  thumbnail={review.exhibition.thumbnail}
-                />
-              ))
-            ) : (
-              <Spinner height="50vh" />
-            )}
-          </ReviewContainer>
-          <Pagination
-            defaultCurrent={likedReview.currentPage}
-            pageSize={likedReview.pageSize}
-            total={reviewLikeCount}
-            onChange={handleChange}
-            hideOnSinglePage={true}
-            style={paginationStyle}
-          />
-        </Tab>
-        <Tab tab={`좋아하는 전시회 (${exhibitionLikeCount})`} key="LIKED_EXHIBITION">
-          <ExhibitionContainer>
-            {isLoaded ? (
-              likedExhibition.payload.map((exhibition) => (
-                <ExhibitionCard key={exhibition.exhibitionId} data={exhibition} />
-              ))
-            ) : (
-              <Spinner height="50vh" />
-            )}
-          </ExhibitionContainer>
-          <Pagination
-            defaultCurrent={likedExhibition.currentPage}
-            pageSize={likedExhibition.pageSize}
-            total={userInfo.exhibitionLikeCount}
-            hideOnSinglePage={true}
-            onChange={handleChange}
-            style={paginationStyle}
-          />
-        </Tab>
-      </TabCardContainer>
-      <SideNavigation
-        paths={[
-          {
-            href: `/users/${userId}`,
-            pageName: '사용자 정보',
-          },
-          {
-            href: `/users/${userId}/edit`,
-            pageName: '프로필 수정',
-          },
-          {
-            href: `/users/${userId}/edit-password`,
-            pageName: '비밀번호 변경',
-          },
-        ]}
-      />
+      <UserProfileCard userId={String(id)} />
+      <UserActivityCardList userId={String(id)} />
+      {isMyPage && (
+        <SideNavigation
+          paths={[
+            {
+              href: `/users/${userId}`,
+              pageName: '사용자 정보',
+            },
+            {
+              href: `/users/${userId}/edit`,
+              pageName: '프로필 수정',
+            },
+            {
+              href: `/users/${userId}/edit-password`,
+              pageName: '비밀번호 변경',
+            },
+          ]}
+        />
+      )}
     </PageContainer>
   );
 };
@@ -229,48 +42,5 @@ const PageContainer = styled.div`
   margin: 0 auto;
   text-align: center;
 `;
-
-const TabCardContainer = styled(Tabs)`
-  margin-top: 30px;
-`;
-
-const Tab = styled(Tabs.TabPane)`
-  text-align: left;
-`;
-
-const ReviewContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  justify-content: center;
-  justify-items: center;
-  gap: 10px;
-  padding: 0 70px 30px 70px;
-
-  @media screen and (max-width: ${({ theme }) => theme.breakPoint.mobile}) {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const ExhibitionContainer = styled.div`
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  justify-content: center;
-  justify-items: center;
-  gap: 10px;
-  padding-bottom: 30px;
-
-  @media screen and (max-width: ${({ theme }) => theme.breakPoint.tablet}) {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  @media screen and (max-width: ${({ theme }) => theme.breakPoint.mobile}) {
-    grid-template-columns: 1fr;
-  }
-`;
-
-const paginationStyle: CSSProperties = {
-  textAlign: 'center',
-  marginBottom: '24px',
-};
 
 export default UserPage;

--- a/pages/users/[id]/index.tsx
+++ b/pages/users/[id]/index.tsx
@@ -1,13 +1,12 @@
 import styled from '@emotion/styled';
-import { Tabs, Image, Pagination } from 'antd';
-import { ReviewCard, ExhibitionCard, SideNavigation } from 'components/molecules';
+import { Tabs, Pagination } from 'antd';
+import { UserProfileCard, ReviewCard, ExhibitionCard, SideNavigation } from 'components/molecules';
 import { userAPI } from 'apis';
 import { CSSProperties, Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
 import { ReviewCardProps, ExhibitionProps } from 'types/model';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
 import { Spinner } from 'components/atoms';
-import DEFAULT_IMAGE from 'constants/defaultImage';
 import { AxiosResponse } from 'axios';
 
 interface UserActivity<T> {
@@ -130,11 +129,13 @@ const UserPage = () => {
 
   return (
     <PageContainer>
-      <ProfileContainer>
-        <ProfileImage src={profileImage || DEFAULT_IMAGE.USER_PROFILE} alt="프로필 이미지" />
-        <UserName>{nickname}</UserName>
-        <UserEmail>{email}</UserEmail>
-      </ProfileContainer>
+      <UserProfileCard
+        data={{
+          email,
+          nickname,
+          profileImage,
+        }}
+      />
       <TabCardContainer type="card" tabPosition="top" centered onTabClick={handleTabClick}>
         <Tab tab={`작성한 후기 (${reviewCount})`} key="MY_REVIEW">
           <ReviewContainer>
@@ -227,29 +228,6 @@ const PageContainer = styled.div`
   max-width: 1100px;
   margin: 0 auto;
   text-align: center;
-`;
-
-const ProfileContainer = styled.div`
-  display: inline-flex;
-  flex-direction: column;
-  padding: 20px;
-`;
-
-const ProfileImage = styled(Image)`
-  width: 160px;
-  height: 160px;
-  border-radius: 50%;
-  margin-bottom: 20px;
-`;
-
-const UserName = styled.span`
-  font-size: 2.4rem;
-  font-weight: 700;
-`;
-
-const UserEmail = styled.span`
-  font-size: 1.8rem;
-  color: ${({ theme }) => theme.color.font.dark};
 `;
 
 const TabCardContainer = styled(Tabs)`

--- a/types/apis/user/index.ts
+++ b/types/apis/user/index.ts
@@ -38,14 +38,6 @@ export interface UserInfoExhibitionLikeResponse extends BaseResponse {
   };
 }
 
-// export interface UserMePasswordProps{
-//     message: string;
-// }
-
-// export interface userMeInfoProps{
-//     message: string;
-// }
-
 export interface UserInfoResponse extends BaseResponse {
   data: {
     nickname: string;


### PR DESCRIPTION
# 작업 내용 (TODO)

유저페이지
- [x] UserProfilerCard와 UserActivityCardList를 컴포넌트로 추출
- [x] 각각의 컴포넌트에 SWR을 적용
       (동일한 key를 사용하므로, API는 한 번만 호출됨)

## UserProfilerCard

![image](https://user-images.githubusercontent.com/80658269/192213734-c77d8d43-a7b3-459c-b0b2-4dc78752ab1d.png)

## UserActivityCardList

![image](https://user-images.githubusercontent.com/80658269/192213949-921a89c4-eb1f-4c39-bc2b-a25122d9ba76.png)

close #299 
