### PR TITLE
hotfix: 서버사이드 인증 관련 문제 해결

### DIFF
--- a/apis/comment/index.ts
+++ b/apis/comment/index.ts
@@ -1,6 +1,8 @@
 import { authRequest, unAuthRequest } from 'apis/common';
 import { CommentCreateRequest, CommentUpdateRequest } from 'types/apis/comment';
-import cookie from 'react-cookies';
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
 
 const commentAPI = {
   create: (reviewId: number, payload: CommentCreateRequest) => {
@@ -13,7 +15,7 @@ const commentAPI = {
     return authRequest.delete(`/api/v1/comments/${commentId}`);
   },
   getReplies: ({ commentId, page, size }: { commentId: number; page?: number; size?: number }) => {
-    const refreshToken = cookie.load('REFRESH_TOKEN');
+    const refreshToken = cookies.get('REFRESH_TOKEN');
     const params = {
       ...(page ? { page: page } : {}),
       ...(size ? { size: size } : {}),

--- a/apis/common.ts
+++ b/apis/common.ts
@@ -1,8 +1,10 @@
 import { userAPI } from 'apis';
 import axios from 'axios';
 import { parseJwt, setToken, storage } from 'utils';
-import cookie from 'react-cookies';
+import { Cookies } from 'react-cookie';
 const baseURL = `${process.env.NEXT_PUBLIC_API_END_POINT}`;
+
+const cookies = new Cookies();
 
 const authRequest = axios.create({
   baseURL,
@@ -14,7 +16,7 @@ const unAuthRequest = axios.create({
 
 authRequest.interceptors.request.use((config) => {
   if (config.headers) {
-    config.headers.accessToken = cookie.load('ACCESS_TOKEN');
+    config.headers.accessToken = cookies.get('ACCESS_TOKEN');
     return config;
   }
 });
@@ -35,8 +37,9 @@ authRequest.interceptors.response.use(
           error.response.data.code === LOGOUT_TOKEN))
     ) {
       originalRequest._retry = true;
-      const accessToken = cookie.load('ACCESS_TOKEN');
-      const refreshToken = cookie.load('REFRESH_TOKEN');
+
+      const accessToken = cookies.get('ACCESS_TOKEN');
+      const refreshToken = cookies.get('REFRESH_TOKEN');
 
       const { userId } = parseJwt(accessToken);
 

--- a/apis/common.ts
+++ b/apis/common.ts
@@ -45,8 +45,8 @@ authRequest.interceptors.response.use(
 
       const tokenRequestBody = {
         userId: parseInt(userId),
-        accessToken: accessToken,
-        refreshToken: refreshToken,
+        accessToken,
+        refreshToken,
       };
 
       const { data } = await userAPI.reissueToken(tokenRequestBody);

--- a/apis/common.ts
+++ b/apis/common.ts
@@ -1,6 +1,6 @@
 import { userAPI } from 'apis';
 import axios from 'axios';
-import { parseJwt, setToken, storage } from 'utils';
+import { parseJwt, setToken } from 'utils';
 import { Cookies } from 'react-cookie';
 const baseURL = `${process.env.NEXT_PUBLIC_API_END_POINT}`;
 

--- a/apis/exhibition/index.ts
+++ b/apis/exhibition/index.ts
@@ -1,5 +1,7 @@
 import { unAuthRequest, authRequest } from 'apis/common';
-import cookie from 'react-cookies';
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
 
 const exhibitionAPI = {
   getUpcoming: (page: number, size: number) => {
@@ -11,7 +13,7 @@ const exhibitionAPI = {
     );
   },
   getDetail: (exhibitionId: number) => {
-    const refreshToken = cookie.load('REFRESH_TOKEN');
+    const refreshToken = cookies.get('REFRESH_TOKEN');
 
     return refreshToken
       ? authRequest.get(`/api/v1/exhibitions/${exhibitionId}`)

--- a/apis/exhibition/index.ts
+++ b/apis/exhibition/index.ts
@@ -4,6 +4,7 @@ import { Cookies } from 'react-cookie';
 const cookies = new Cookies();
 
 const exhibitionAPI = {
+  // 여기 auth 반영 안되어있음
   getUpcoming: (page: number, size: number) => {
     return unAuthRequest.get(`/api/v1/exhibitions/upcoming?page=${page}&size=${size}`);
   },

--- a/apis/review/index.ts
+++ b/apis/review/index.ts
@@ -1,12 +1,14 @@
 import { authRequest, unAuthRequest } from 'apis/common';
-import cookie from 'react-cookies';
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
 
 const reviewAPI = {
   likeToggle: (reviewId: number) => {
     return authRequest.patch(`/api/v1/reviews/${reviewId}/like`);
   },
   getComments: ({ reviewId, page, size }: { reviewId: number; page?: number; size?: number }) => {
-    const refreshToken = cookie.load('REFRESH_TOKEN');
+    const refreshToken = cookies.get('REFRESH_TOKEN');
     const params = {
       ...(page ? { page: page } : {}),
       ...(size ? { size: size } : {}),
@@ -34,7 +36,7 @@ const reviewAPI = {
     size?: number;
     sort?: string;
   }) => {
-    const refreshToken = cookie.load('REFRESH_TOKEN');
+    const refreshToken = cookies.get('REFRESH_TOKEN');
 
     const params = {
       ...(exhibitionId ? { exhibitionId: exhibitionId } : {}),
@@ -52,7 +54,7 @@ const reviewAPI = {
         });
   },
   getReviewSingle: (reviewId: number) => {
-    const refreshToken = cookie.load('REFRESH_TOKEN');
+    const refreshToken = cookies.get('REFRESH_TOKEN');
 
     return refreshToken
       ? authRequest.get(`/api/v1/reviews/${reviewId}`)

--- a/apis/user/index.ts
+++ b/apis/user/index.ts
@@ -5,7 +5,9 @@ import {
   UserSignupRequest,
   UserChangePasswordRequest,
 } from 'types/apis/user';
-import cookie from 'react-cookies';
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
 
 const userAPI = {
   localLogin: (payload: UserLocalLoginRequest) => {
@@ -33,15 +35,15 @@ const userAPI = {
     return unAuthRequest.get(`/api/v1/users/${userId}/info`);
   },
   getMyReview: (userId: number, page: number, size: number) => {
-    const request = cookie.load('REFRESH_TOKEN') ? authRequest : unAuthRequest;
+    const request = cookies.get('REFRESH_TOKEN') ? authRequest : unAuthRequest;
     return request.get(`/api/v1/users/${userId}/info/my/reviews?page=${page}&size=${size}`);
   },
   getLikedReview: (userId: number, page: number, size: number) => {
-    const request = cookie.load('REFRESH_TOKEN') ? authRequest : unAuthRequest;
+    const request = cookies.get('REFRESH_TOKEN') ? authRequest : unAuthRequest;
     return request.get(`/api/v1/users/${userId}/info/reviews/like?page=${page}&size=${size}`);
   },
   getLikedExhibition: (userId: number, page: number, size: number) => {
-    const request = cookie.load('REFRESH_TOKEN') ? authRequest : unAuthRequest;
+    const request = cookies.get('REFRESH_TOKEN') ? authRequest : unAuthRequest;
     return request.get(`/api/v1/users/${userId}/info/exhibitions/like?page=${page}&size=${size}`);
   },
   changeMyInfo: (formData: FormData) => {

--- a/components/molecules/ExhibitionCard/index.tsx
+++ b/components/molecules/ExhibitionCard/index.tsx
@@ -21,6 +21,8 @@ const ExhibitionCard = ({ data }: ExhibitionCardProps) => {
   const { exhibitionId, name, thumbnail, startDate, endDate, likeCount, reviewCount, isLiked } =
     data;
 
+  // console.log('data', data);
+
   const dDay = displayDday(startDate);
   const mouseHover = () => setIsHover((isHover) => !isHover);
 

--- a/components/organisms/CommentWrite/index.tsx
+++ b/components/organisms/CommentWrite/index.tsx
@@ -8,9 +8,9 @@ import router from 'next/router';
 import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
 import { commentAPI } from 'apis';
-
+import DEFAULT_IMAGE from 'constants/defaultImage';
 interface CommentWriteProps {
-  // isLogin: boolean;
+  isLogin: boolean;
   reviewId: number;
   onCommentReload?: () => void;
   parentId?: number;
@@ -26,8 +26,8 @@ const CommentWrite = ({
   const [show, setShow] = useState(false);
   const [comment, setComment] = useState('');
   const commentContainerRef = useRef<HTMLDivElement>(null);
-  const currentUser = useRecoilValue(userAtom);
-  const isLogin = currentUser.userId !== null;
+  const { userId, email, nickname, profileImage, isLoggedIn } = useRecoilValue(userAtom);
+  // const isLogin = currentUser.userId !== null;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setComment(e.target.value);
@@ -63,7 +63,7 @@ const CommentWrite = ({
   };
 
   {
-    return !isLogin ? (
+    return !isLoggedIn ? (
       <CommentWriteContainer
         onClick={() => {
           router.push('/signin');
@@ -75,7 +75,12 @@ const CommentWrite = ({
     ) : (
       <CommentWriteWrapper ref={commentContainerRef}>
         <CommentWriteContainer>
-          {/* <UserAvatar userId={currentUser.userId} profileImage={currentUser.profileImage} /> */}
+          {userId && (
+            <UserAvatar
+              userId={userId}
+              profileImage={profileImage ? profileImage : DEFAULT_IMAGE.USER_PROFILE}
+            />
+          )}
           <CommentInput
             value={comment}
             placeholder="댓글을 작성하세요."

--- a/components/organisms/CommentWrite/index.tsx
+++ b/components/organisms/CommentWrite/index.tsx
@@ -10,7 +10,6 @@ import { userAtom } from 'states';
 import { commentAPI } from 'apis';
 import DEFAULT_IMAGE from 'constants/defaultImage';
 interface CommentWriteProps {
-  isLogin: boolean;
   reviewId: number;
   onCommentReload?: () => void;
   parentId?: number;
@@ -26,8 +25,7 @@ const CommentWrite = ({
   const [show, setShow] = useState(false);
   const [comment, setComment] = useState('');
   const commentContainerRef = useRef<HTMLDivElement>(null);
-  const { userId, email, nickname, profileImage, isLoggedIn } = useRecoilValue(userAtom);
-  // const isLogin = currentUser.userId !== null;
+  const { userId, profileImage, isLoggedIn } = useRecoilValue(userAtom);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setComment(e.target.value);

--- a/components/organisms/CommentWrite/index.tsx
+++ b/components/organisms/CommentWrite/index.tsx
@@ -75,7 +75,7 @@ const CommentWrite = ({
     ) : (
       <CommentWriteWrapper ref={commentContainerRef}>
         <CommentWriteContainer>
-          <UserAvatar userId={currentUser.userId} profileImage={currentUser.profileImage} />
+          {/* <UserAvatar userId={currentUser.userId} profileImage={currentUser.profileImage} /> */}
           <CommentInput
             value={comment}
             placeholder="댓글을 작성하세요."

--- a/components/templates/Layout/index.tsx
+++ b/components/templates/Layout/index.tsx
@@ -5,7 +5,7 @@ import { Header, Footer } from '../../organisms';
 const Layout = ({ children }: { children: ReactElement }) => {
   return (
     <PageContainer>
-      <Header />
+      {/* <Header /> */}
       {children}
       <Footer />
     </PageContainer>

--- a/components/templates/Layout/index.tsx
+++ b/components/templates/Layout/index.tsx
@@ -5,7 +5,7 @@ import { Header, Footer } from '../../organisms';
 const Layout = ({ children }: { children: ReactElement }) => {
   return (
     <PageContainer>
-      {/* <Header /> */}
+      <Header />
       {children}
       <Footer />
     </PageContainer>

--- a/hooks/useUserAuthActions/index.ts
+++ b/hooks/useUserAuthActions/index.ts
@@ -21,6 +21,7 @@ function useUserAuthActions() {
       try {
         const res = await userAPI.localLogin(values);
         const { accessToken, refreshToken } = res.data.data;
+
         setToken('ACCESS_TOKEN', accessToken);
         setToken('REFRESH_TOKEN', refreshToken);
         const { data } = await userAPI.getMyInfo();
@@ -45,8 +46,8 @@ function useUserAuthActions() {
       try {
         await userAPI.logout();
         setUser(SIGNOUT_USER_STATE);
-        cookies.get('REFRESH_TOKEN');
-        cookies.get('ACCESS_TOKEN');
+        cookies.remove('REFRESH_TOKEN');
+        cookies.remove('ACCESS_TOKEN');
         message.success('로그아웃 되었습니다.');
         router.push('/');
       } catch (e) {

--- a/hooks/useUserAuthActions/index.ts
+++ b/hooks/useUserAuthActions/index.ts
@@ -46,8 +46,8 @@ function useUserAuthActions() {
       try {
         await userAPI.logout();
         setUser(SIGNOUT_USER_STATE);
-        cookies.remove('REFRESH_TOKEN');
-        cookies.remove('ACCESS_TOKEN');
+        cookies.remove('REFRESH_TOKEN', { path: '/' });
+        cookies.remove('ACCESS_TOKEN', { path: '/' });
         message.success('로그아웃 되었습니다.');
         router.push('/');
       } catch (e) {

--- a/hooks/useUserAuthActions/index.ts
+++ b/hooks/useUserAuthActions/index.ts
@@ -4,10 +4,12 @@ import { useSetRecoilState } from 'recoil';
 import { userAtom } from 'states';
 import { UserLocalLoginRequest } from 'types/apis/user';
 import { setToken, getErrorMessage } from 'utils';
-import cookie from 'react-cookies';
+import { Cookies } from 'react-cookie';
 import { message } from 'antd';
 import { SIGNOUT_USER_STATE } from '../../constants';
 import { useState } from 'react';
+
+const cookies = new Cookies();
 
 function useUserAuthActions() {
   const [isLoading, setIsLoading] = useState(false);
@@ -43,8 +45,8 @@ function useUserAuthActions() {
       try {
         await userAPI.logout();
         setUser(SIGNOUT_USER_STATE);
-        cookie.remove('REFRESH_TOKEN');
-        cookie.remove('ACCESS_TOKEN');
+        cookies.get('REFRESH_TOKEN');
+        cookies.get('ACCESS_TOKEN');
         message.success('로그아웃 되었습니다.');
         router.push('/');
       } catch (e) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "next-cookies": "^2.0.3",
     "react": "18.2.0",
     "react-cookie": "^4.1.1",
-    "react-cookies": "^0.1.1",
     "react-dom": "18.2.0",
     "recoil": "^0.7.4",
     "sass": "^1.54.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "next": "12.2.2",
     "next-cookies": "^2.0.3",
     "react": "18.2.0",
+    "react-cookie": "^4.1.1",
     "react-cookies": "^0.1.1",
     "react-dom": "18.2.0",
     "recoil": "^0.7.4",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
 import '../styles/globals.css';
 import type { AppContext, AppProps } from 'next/app';
-import { RecoilRoot } from 'recoil';
+import { MutableSnapshot, RecoilRoot, useSetRecoilState } from 'recoil';
 import { Layout } from 'components/templates';
 import { ThemeProvider } from '@emotion/react';
 import theme from 'styles/global/theme';
@@ -9,12 +9,13 @@ import 'swiper/scss/navigation';
 import 'swiper/scss/pagination';
 import cookies from 'next-cookies';
 import App from 'next/app';
-import { setToken } from 'utils';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { SWRConfig } from 'swr';
 import { swrOptions } from 'utils';
-
+import axios from 'axios';
+import { userAtom } from 'states';
+import { SIGNOUT_USER_STATE } from '../constants';
 declare global {
   interface Window {
     // eslint-disable-next-line
@@ -22,15 +23,23 @@ declare global {
   }
 }
 
-function ArtZip({ Component, pageProps }: AppProps) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ArtZip({ Component, pageProps, userData }: AppProps | any) {
   const { pathname } = useRouter();
+
+  const initialState = ({ set }: MutableSnapshot) => {
+    const { userId, email, nickname, profileImage } = userData;
+    const isLoggedIn = userId !== null;
+    console.log(userId, email, nickname, profileImage, isLoggedIn);
+    set(userAtom, { userId, email, nickname, profileImage, isLoggedIn });
+  };
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [pathname]);
 
   return (
-    <RecoilRoot>
+    <RecoilRoot initializeState={initialState}>
       <SWRConfig value={swrOptions}>
         <ThemeProvider theme={theme}>
           <Layout>
@@ -41,5 +50,34 @@ function ArtZip({ Component, pageProps }: AppProps) {
     </RecoilRoot>
   );
 }
+
+ArtZip.getInitialProps = async (appContext: AppContext) => {
+  const appProps = await App.getInitialProps(appContext);
+  const { ctx } = appContext;
+  const allCookies = cookies(ctx);
+
+  const accessToken = allCookies['ACCESS_TOKEN'];
+  const refreshToken = allCookies['REFRESH_TOKEN'];
+
+  let userState = SIGNOUT_USER_STATE;
+
+  if (refreshToken) {
+    // 이 값을 통하여 내 정보를 조회하기
+    const headers = {
+      ...(accessToken ? { accessToken: accessToken } : {}),
+    };
+    const { data } = await axios.get(
+      `${process.env.NEXT_PUBLIC_API_END_POINT}api/v1/users/me/info`,
+      {
+        headers,
+      },
+    );
+
+    userState = data.data;
+  }
+
+  // console.log('userState', userState);
+  return { ...appProps, userData: userState };
+};
 
 export default ArtZip;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -28,9 +28,6 @@ declare global {
 function ArtZip({ Component, pageProps, userData }: AppProps | any) {
   const { pathname } = useRouter();
 
-  // TODO: 테스트용 콘솔 지우기
-  console.log('userData', userData);
-
   const initialState = ({ set }: MutableSnapshot) => {
     const { userId, email, nickname, profileImage } = userData;
     const isLoggedIn = userId !== null;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -42,22 +42,4 @@ function ArtZip({ Component, pageProps }: AppProps) {
   );
 }
 
-ArtZip.getInitialProps = async (appContext: AppContext) => {
-  const appProps = await App.getInitialProps(appContext);
-  const { ctx } = appContext;
-  const allCookies = cookies(ctx);
-
-  const accessTokenByCookie = allCookies['ACCESS_TOKEN'];
-  const refreshTokenByCookie = allCookies['REFRESH_TOKEN'];
-
-  // TODO: setToken의 로직 수정, 토큰 자체를 디코드하여 유효기간을 설정하기
-  // 현재 배포에서는 쿠키 확인 불가
-  if (refreshTokenByCookie) {
-    accessTokenByCookie && setToken('ACCESS_TOKEN', accessTokenByCookie);
-    refreshTokenByCookie && setToken('REFRESH_TOKEN', refreshTokenByCookie);
-  }
-
-  return { ...appProps };
-};
-
 export default ArtZip;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,6 +9,7 @@ import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
 import { exhibitionAPI } from 'apis';
 import { ExhibitionProps } from 'types/model';
+import axios from 'axios';
 
 interface HomeProps {
   upcomingExhibitions: Required<ExhibitionProps>[];
@@ -33,10 +34,30 @@ const Home: NextPage<HomeProps> = ({ upcomingExhibitions, mostLikeExhibitions })
   );
 };
 
-export const getServerSideProps = async () => {
+export const getServerSideProps = async (context: GetServerSidePropsContext) => {
+  const accessToken = context.req.cookies['ACCESS_TOKEN'];
+
+  const headers = {
+    ...(accessToken ? { accessToken: accessToken } : {}),
+  };
+
+  const getUpcoming = axios.get(
+    `${process.env.NEXT_PUBLIC_API_END_POINT}api/v1/exhibitions/upcoming?page=0&size=8`,
+    {
+      headers,
+    },
+  );
+
+  const getMostLike = axios.get(
+    `${process.env.NEXT_PUBLIC_API_END_POINT}api/v1/exhibitions/mostlike?page=0&size=8&include-end=true`,
+    {
+      headers,
+    },
+  );
+
   const [upcomingExhibitionRes, mostLikeExhibitionRes] = await Promise.all([
-    exhibitionAPI.getUpcoming(0, 8),
-    exhibitionAPI.getMostLike(0, 8, true),
+    getUpcoming,
+    getMostLike,
   ]);
 
   return {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,13 +1,8 @@
-import Map from 'components/atoms/Map';
-import ExhibitionCard from 'components/molecules/ExhibitionCard';
 import SwiperWrapper from 'components/organisms/Swiper';
 import SwiperContainer from 'components/organisms/SwiperContainer';
 import type { GetServerSidePropsContext, NextPage } from 'next';
-import { ExhibitionReadResponse } from 'types/apis/exhibition';
 import { homeStyle as S } from '../styles/pages';
-import React, { useEffect, useState } from 'react';
 import Head from 'next/head';
-import { exhibitionAPI } from 'apis';
 import { ExhibitionProps } from 'types/model';
 import axios from 'axios';
 

--- a/pages/users/[id]/edit/index.tsx
+++ b/pages/users/[id]/edit/index.tsx
@@ -18,20 +18,22 @@ import DEFAULT_IMAGE from 'constants/defaultImage';
 import { Spinner } from 'components/atoms';
 
 interface SubmitData {
-  nickname: string;
-  profileImage: string;
+  nickname: string | null;
+  profileImage: string | null;
 }
 
 const UserEditPage = () => {
   const [form] = useForm();
   const [userInfo, setUserInfo] = useRecoilState(userAtom);
   const { userId, nickname, profileImage } = userInfo;
+
   const submitData = useRef<SubmitData>({
     nickname: nickname,
     profileImage: profileImage,
   });
+
   const submitFile = useRef<FileList>();
-  const [previewImage, setPreviewImage] = useState(profileImage);
+  const [previewImage, setPreviewImage] = useState<string | null>(profileImage);
   const fileInput = useRef<HTMLInputElement>(null);
 
   const handleImageClick = () => {

--- a/states/user.ts
+++ b/states/user.ts
@@ -1,26 +1,41 @@
 import { userAPI } from 'apis';
 import { atom, selector } from 'recoil';
-import cookie from 'react-cookies';
+import { Cookies } from 'react-cookie';
 import { SIGNOUT_USER_STATE } from '../constants';
+
+const cookies = new Cookies();
 
 const cookieEffect =
   (accessTokenKey: string, refreshTokenKey: string) =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ({ setSelf, onSet }: any) => {
-    const accessToken = cookie.load(accessTokenKey);
-    const refreshToken = cookie.load(refreshTokenKey);
+    const accessToken = cookies.get(accessTokenKey);
+    const refreshToken = cookies.get(refreshTokenKey);
+
+    console.log('accessToken', accessToken);
+    console.log('refreshToken', refreshToken);
 
     if (!accessToken || !refreshToken) {
-      cookie.remove('ACCESS_TOKEN');
-      cookie.remove('REFRESH_TOKEN');
+      cookies.remove('ACCESS_TOKEN');
+      cookies.remove('REFRESH_TOKEN');
       setSelf(SIGNOUT_USER_STATE);
+    } else {
+      console.log('else 조건문');
+      setSelf(async () => {
+        const { data } = await userAPI.getMyInfo();
+        console.log('data', data);
+        const { userId, email, nickname, profileImage } = data.data;
+        return { userId, email, nickname, profileImage, isLoggedIn: true };
+      });
     }
 
     onSet(async () => {
+      // console.log('onSet');
+
       try {
-        if (!cookie.load(accessTokenKey) || !cookie.load(refreshTokenKey)) {
-          cookie.remove('ACCESS_TOKEN');
-          cookie.remove('REFRESH_TOKEN');
+        if (!cookies.get(accessTokenKey) || !cookies.get(refreshTokenKey)) {
+          cookies.remove('ACCESS_TOKEN');
+          cookies.remove('REFRESH_TOKEN');
           return SIGNOUT_USER_STATE;
         }
 
@@ -28,8 +43,8 @@ const cookieEffect =
         const { userId, email, nickname, profileImage } = data.data;
         return { userId, email, nickname, profileImage, isLoggedIn: true };
       } catch (error: unknown) {
-        cookie.remove('ACCESS_TOKEN');
-        cookie.remove('REFRESH_TOKEN');
+        cookies.remove('ACCESS_TOKEN');
+        cookies.remove('REFRESH_TOKEN');
         console.error(error);
 
         return SIGNOUT_USER_STATE;
@@ -38,28 +53,9 @@ const cookieEffect =
   };
 
 const userAtom = atom({
-  key: 'user',
+  key: `user/${new Date().getMilliseconds}`,
   effects: [cookieEffect('ACCESS_TOKEN', 'REFRESH_TOKEN')],
-  default: selector({
-    key: 'user/get',
-    get: async () => {
-      if (!cookie.load('ACCESS_TOKEN') || !cookie.load('REFRESH_TOKEN')) {
-        cookie.remove('ACCESS_TOKEN');
-        cookie.remove('REFRESH_TOKEN');
-        return SIGNOUT_USER_STATE;
-      }
-
-      try {
-        const { data } = await userAPI.getMyInfo();
-        const { userId, email, nickname, profileImage } = data.data;
-        return { userId, email, nickname, profileImage, isLoggedIn: true };
-      } catch (error: unknown) {
-        cookie.remove('ACCESS_TOKEN');
-        cookie.remove('REFRESH_TOKEN');
-        return SIGNOUT_USER_STATE;
-      }
-    },
-  }),
+  default: SIGNOUT_USER_STATE,
 });
 
 export default userAtom;

--- a/states/user.ts
+++ b/states/user.ts
@@ -9,28 +9,8 @@ const cookieEffect =
   (accessTokenKey: string, refreshTokenKey: string) =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ({ setSelf, onSet }: any) => {
-    const accessToken = cookies.get(accessTokenKey);
-    const refreshToken = cookies.get(refreshTokenKey);
-
-    console.log('accessToken', accessToken);
-    console.log('refreshToken', refreshToken);
-
-    if (!accessToken || !refreshToken) {
-      cookies.remove('ACCESS_TOKEN');
-      cookies.remove('REFRESH_TOKEN');
-      setSelf(SIGNOUT_USER_STATE);
-    } else {
-      console.log('else 조건문');
-      setSelf(async () => {
-        const { data } = await userAPI.getMyInfo();
-        console.log('data', data);
-        const { userId, email, nickname, profileImage } = data.data;
-        return { userId, email, nickname, profileImage, isLoggedIn: true };
-      });
-    }
-
     onSet(async () => {
-      // console.log('onSet');
+      console.log('onSet');
 
       try {
         if (!cookies.get(accessTokenKey) || !cookies.get(refreshTokenKey)) {
@@ -53,7 +33,7 @@ const cookieEffect =
   };
 
 const userAtom = atom({
-  key: `user/${new Date().getMilliseconds}`,
+  key: `user/${new Date().getUTCMilliseconds() * Math.random()}`,
   effects: [cookieEffect('ACCESS_TOKEN', 'REFRESH_TOKEN')],
   default: SIGNOUT_USER_STATE,
 });

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -2,7 +2,7 @@ export { displayDate, displayDday, displayFormattedDate } from './displayedAt';
 export { default as storage } from './storage';
 export { default as throttleOnRendering } from './throttleOnRendering';
 export { convertObjectToFormData, convertFilesToFormData, getBase64 } from './converter';
-export { setToken } from './tokenManager';
+export { setToken, authorizeFetch } from './tokenManager';
 export { parseJwt } from './parseJwt';
 export { swrOptions } from './swrOptions';
 export { getErrorMessage } from './errorHandling';

--- a/utils/swrOptions/index.ts
+++ b/utils/swrOptions/index.ts
@@ -1,10 +1,12 @@
 import axios from 'axios';
-import cookie from 'react-cookies';
+import { Cookies } from 'react-cookie';
+
+const cookies = new Cookies();
 
 export const swrOptions = {
   fetcher: async (url: string, params: object = {}) => {
-    const isLoggedIn = cookie.load('REFRESH_TOKEN');
-    const accessToken = cookie.load('ACCESS_TOKEN');
+    const isLoggedIn = cookies.get('REFRESH_TOKEN');
+    const accessToken = cookies.get('ACCESS_TOKEN');
 
     if (isLoggedIn) {
       const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_END_POINT}${url}`, {

--- a/utils/tokenManager/index.ts
+++ b/utils/tokenManager/index.ts
@@ -1,17 +1,18 @@
-import cookie from 'react-cookies';
+import { Cookies } from 'react-cookie';
 
 function setToken(key: 'ACCESS_TOKEN' | 'REFRESH_TOKEN', token: string) {
   // 개발 환경에 따라서 설정
-  const HTTP_ONLY = !(process.env.NEXT_PUBLIC_ENVIRONMENT === 'DEVELOP');
+  // const HTTP_ONLY = !(process.env.NEXT_PUBLIC_ENVIRONMENT === 'DEVELOP');
   const expires = new Date();
+  const cookies = new Cookies();
 
   expires.setDate(expires.getDate() + 14);
 
-  cookie.save(key, token, {
+  cookies.set(key, token, {
     path: '/',
     expires: key === 'REFRESH_TOKEN' ? expires : undefined,
     // domain: process.env.NEXT_PUBLIC_ENVIRONMENT === 'DEVELOP' ? '' : '.artzip.shop',
-    httpOnly: HTTP_ONLY,
+    // httpOnly: HTTP_ONLY,
   });
 }
 

--- a/utils/tokenManager/index.ts
+++ b/utils/tokenManager/index.ts
@@ -1,7 +1,11 @@
+import { userAPI } from 'apis';
+import axios, { AxiosError } from 'axios';
 import { Cookies } from 'react-cookie';
+import { parseJwt } from 'utils/parseJwt';
 
 function setToken(key: 'ACCESS_TOKEN' | 'REFRESH_TOKEN', token: string) {
   // 개발 환경에 따라서 설정
+
   // const HTTP_ONLY = !(process.env.NEXT_PUBLIC_ENVIRONMENT === 'DEVELOP');
   const expires = new Date();
   const cookies = new Cookies();
@@ -11,9 +15,58 @@ function setToken(key: 'ACCESS_TOKEN' | 'REFRESH_TOKEN', token: string) {
   cookies.set(key, token, {
     path: '/',
     expires: key === 'REFRESH_TOKEN' ? expires : undefined,
-    // domain: process.env.NEXT_PUBLIC_ENVIRONMENT === 'DEVELOP' ? '' : '.artzip.shop',
     // httpOnly: HTTP_ONLY,
   });
 }
 
-export { setToken };
+async function authorizeFetch({
+  accessToken,
+  refreshToken,
+  apiURL,
+}: {
+  accessToken: string;
+  refreshToken: string;
+  apiURL: string;
+}) {
+  const headers = {
+    ...(accessToken ? { accessToken: accessToken } : {}),
+  };
+
+  try {
+    const { data } = await axios.get(apiURL, {
+      headers,
+    });
+    return { isAuth: true, data: data.data };
+  } catch (e) {
+    if (e instanceof AxiosError) {
+      if (e.response && e.response.status === 401) {
+        const { userId } = parseJwt(accessToken as string);
+
+        try {
+          const { data: newTokenData } = await userAPI.reissueToken({
+            userId: parseInt(userId),
+            accessToken,
+            refreshToken,
+          });
+
+          const newAccessToken = newTokenData.data.accessToken;
+          setToken('ACCESS_TOKEN', newAccessToken);
+
+          const { data: newAuthData } = await axios.get(apiURL, {
+            headers: {
+              accessToken: newAccessToken,
+            },
+          });
+
+          return { isAuth: true, data: newAuthData.data };
+        } catch (e) {
+          const { data } = await axios.get(apiURL);
+          return { isAuth: false, data: data.data };
+        }
+      }
+    }
+    const { data } = await axios.get(apiURL);
+    return { isAuth: false, data: data.data };
+  }
+}
+export { setToken, authorizeFetch };

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,6 +473,14 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/hoist-non-react-statics@^3.0.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/js-levenshtein@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz#ba05426a43f9e4e30b631941e0aa17bf0c890ed5"
@@ -1864,7 +1872,7 @@ headers-polyfill@^3.0.4:
   resolved "https://registry.yarnpkg.com/headers-polyfill/-/headers-polyfill-3.0.10.tgz#51a72c0d9c32594fd23854a564c3d6c80b46b065"
   integrity sha512-lOhQU7iG3AMcjmb8NIWCa+KwfJw5bY44BoWPtrj5A4iDbSD3ylGf5QcYr0ZyQnhkKQ2GgWNLdF2rfrXtXlF3nQ==
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -3089,6 +3097,15 @@ rc-virtual-list@^3.2.0, rc-virtual-list@^3.4.8:
     rc-resize-observer "^1.0.0"
     rc-util "^5.15.0"
 
+react-cookie@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-4.1.1.tgz#832e134ad720e0de3e03deaceaab179c4061a19d"
+  integrity sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.0.1"
+    hoist-non-react-statics "^3.0.0"
+    universal-cookie "^4.0.0"
+
 react-cookies@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/react-cookies/-/react-cookies-0.1.1.tgz#2a35807e04f5a13f58ccd1a9fb66574506873c88"
@@ -3621,7 +3638,7 @@ unbox-primitive@^1.0.2:
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
 
-universal-cookie@^4.0.2:
+universal-cookie@^4.0.0, universal-cookie@^4.0.2:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
   integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1123,11 +1123,6 @@ convert-source-map@^1.5.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-cookie@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
-  integrity sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==
-
 cookie@^0.4.0, cookie@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
@@ -3105,14 +3100,6 @@ react-cookie@^4.1.1:
     "@types/hoist-non-react-statics" "^3.0.1"
     hoist-non-react-statics "^3.0.0"
     universal-cookie "^4.0.0"
-
-react-cookies@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/react-cookies/-/react-cookies-0.1.1.tgz#2a35807e04f5a13f58ccd1a9fb66574506873c88"
-  integrity sha512-PP75kJ4vtoHuuTdq0TAD3RmlAv7vuDQh9fkC4oDlhntgs9vX1DmREomO0Y1mcQKR9nMZ6/zxoflaMJ3MAmF5KQ==
-  dependencies:
-    cookie "^0.3.1"
-    object-assign "^4.1.1"
 
 react-dom@18.2.0:
   version "18.2.0"


### PR DESCRIPTION
# 작업 내용 (TODO)

구현 완료! 코드 리뷰 부탁드리겠습니다 :) @gitul0515  @yunjjeongjo  @Hyevvy 

- [x] `react-cookies` 라이브러리를 `react-cookie` 라이브러리로 교체
[refactor: cookie 관련 코드 라이브러리 변경](https://github.com/prgrms-web-devcourse/Team-BackFro-ArtZip-FE/pull/301/commits/2e2b8fc6d8c62297e15affa8107009723c263576)
- [x] 배포 시 로그인 유지 안되던 문제 해결 (앱 진입 시 recoil 초기 상태 설정)
[feat: 앱 진입 시(새로고침 시) recoil 초기 상태 설정](https://github.com/prgrms-web-devcourse/Team-BackFro-ArtZip-FE/pull/301/commits/c050bc427cc1e5ffe23e8f6f048b1b69eeb2d953)
- [x] 서버 사이드에서 쿠키의 값을 읽을 수 없던 문제 해결
- [x] 서버 사이드 용 토큰 재발행 로직 구현, 서버 사이드에서 토큰을 통해 데이터를 불러오는 함수 `authorizeFetch` 구현
[feat: SSR 에서 토큰 재발행 로직 구현](https://github.com/prgrms-web-devcourse/Team-BackFro-ArtZip-FE/pull/301/commits/0eaa64c70c5cc8764133f27560c43b3c1e7969c5)

# 사진 (구현 캡쳐)

직접 배포 사이트에 들어가서 테스트 부탁드리겠습니다!

# 논의하고 싶은 부분

- HTTP only cookie의 경우, 저희 코드(CSR)에서도 읽을 수 없는 문제가 발생되어 적용하지 못하였습니다 ㅠㅠ

close #192 

