### PR TITLE
refactor: SWR 캐시로 인한 깜빡임 현상 수정

### DIFF
--- a/components/organisms/ReviewDetail/index.tsx
+++ b/components/organisms/ReviewDetail/index.tsx
@@ -3,11 +3,12 @@ import { reviewAPI } from 'apis';
 import { LinkButton } from 'components/atoms';
 import { UserInfo, ImageGroup, ReviewExhibitionInfo } from 'components/molecules';
 import { InfoGroup } from 'components/organisms';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
 import { ReviewSingleReadData } from 'types/apis/review';
 import * as S from './style';
+import { useSWRConfig } from 'swr';
 
 interface ReviewDetailProps {
   reviewDetail: Omit<ReviewSingleReadData, 'comments'>;
@@ -36,11 +37,7 @@ const ReviewDetail = ({ reviewDetail, commentCount, onDeleteButtonClick }: Revie
   const [isLikeDetail, setIsLikedFeed] = useState(isLiked);
   const [likeLoading, setLikeLoading] = useState(false);
   const userState = useRecoilValue(userAtom);
-
-  useEffect(() => {
-    setIsLikedFeed(isLiked);
-    setDetailLikeCount(likeCount);
-  }, [isLiked, likeCount]);
+  const { mutate } = useSWRConfig();
 
   const handleLikeClick = async (reviewId: number) => {
     if (!userState.userId) {
@@ -62,6 +59,16 @@ const ReviewDetail = ({ reviewDetail, commentCount, onDeleteButtonClick }: Revie
     setDetailLikeCount(likeCount);
 
     setLikeLoading(false);
+
+    mutate(
+      `api/v1/reviews/${reviewId}`,
+      {
+        ...reviewDetail,
+        isLiked,
+        likeCount,
+      },
+      { revalidate: false },
+    );
   };
 
   return (

--- a/components/organisms/ReviewFeed/index.tsx
+++ b/components/organisms/ReviewFeed/index.tsx
@@ -35,11 +35,6 @@ const ReviewFeed = ({ feed, isMyFeed, onDeleteButtonClick }: ReviewFeedProps) =>
   const [isModalVisible, setIsModalVisible] = useState(false);
   const { mutate } = useSWRConfig();
 
-  useEffect(() => {
-    setIsLikedFeed(isLiked);
-    setFeedLikeCount(likeCount);
-  }, [isLiked, likeCount]);
-
   const showModal = () => {
     setIsModalVisible(true);
   };

--- a/components/organisms/ReviewFeed/index.tsx
+++ b/components/organisms/ReviewFeed/index.tsx
@@ -11,6 +11,7 @@ import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
 import { reviewAPI } from 'apis';
 import Image from 'next/image';
+import { useSWRConfig } from 'swr';
 
 const ReviewFeed = ({ feed, isMyFeed, onDeleteButtonClick }: ReviewFeedProps) => {
   const router = useRouter();
@@ -32,6 +33,7 @@ const ReviewFeed = ({ feed, isMyFeed, onDeleteButtonClick }: ReviewFeedProps) =>
   const [feedLikeCount, setFeedLikeCount] = useState(likeCount);
   const [likeLoading, setLikeLoading] = useState(false);
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const { mutate } = useSWRConfig();
 
   useEffect(() => {
     setIsLikedFeed(isLiked);
@@ -77,6 +79,8 @@ const ReviewFeed = ({ feed, isMyFeed, onDeleteButtonClick }: ReviewFeedProps) =>
     setFeedLikeCount(likeCount);
 
     setLikeLoading(false);
+
+    mutate(`api/v1/reviews/${reviewId}`, undefined, { revalidate: true });
   };
 
   return (

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -27,7 +27,7 @@ const CommunityPage = () => {
     }?page=${currentPage}`;
   };
 
-  const { data: exhibitionData } = useSWRInfinite(getKey, swrOptions.fetcher);
+  const { data: exhibitionData, mutate } = useSWRInfinite(getKey, swrOptions.fetcher);
 
   useEffect(() => {
     if (exhibitionData) {
@@ -62,6 +62,12 @@ const CommunityPage = () => {
     const { data } = await reviewAPI.getReviewMulti({ exhibitionId: Number(exhibitionId) });
     setFeeds([...data.data.content]);
   };
+
+  useEffect(() => {
+    return () => {
+      mutate(undefined, { revalidate: true });
+    };
+  }, []);
 
   return (
     <>

--- a/pages/reviews/update/[id]/index.tsx
+++ b/pages/reviews/update/[id]/index.tsx
@@ -92,14 +92,19 @@ const ReviewUpdatePage = () => {
         await reviewAPI.updateReview(Number(router.query.id), formData);
         message.success('후기 수정이 완료되었습니다.');
         router.replace('/community');
-        mutate({
-          ...prevData,
-          date: data.date,
-          title: data.title,
-          content: data.content,
-          isPublic: data.isPublic,
-          photos: [...prevImages],
-        });
+        mutate(
+          {
+            ...prevData,
+            date: data.date,
+            title: data.title,
+            content: data.content,
+            isPublic: data.isPublic,
+            photos: [...prevImages],
+          },
+          {
+            revalidate: false,
+          },
+        );
       } catch (error) {
         message.error(getErrorMessage(error));
         console.error(error);

--- a/utils/swrOptions/index.ts
+++ b/utils/swrOptions/index.ts
@@ -1,24 +1,13 @@
-import axios from 'axios';
 import cookie from 'react-cookies';
+import { authRequest, unAuthRequest } from 'apis/common';
 
 export const swrOptions = {
   fetcher: async (url: string, params: object = {}) => {
     const isLoggedIn = cookie.load('REFRESH_TOKEN');
-    const accessToken = cookie.load('ACCESS_TOKEN');
-
-    if (isLoggedIn) {
-      const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_END_POINT}${url}`, {
-        headers: {
-          accessToken,
-        },
-        params,
-      });
-      return data.data;
-    } else {
-      const { data } = await axios.get(`${process.env.NEXT_PUBLIC_API_END_POINT}${url}`, {
-        params,
-      });
-      return data.data;
-    }
+    const request = isLoggedIn ? authRequest : unAuthRequest;
+    const { data } = await request.get(url, {
+      params,
+    });
+    return data.data;
   },
 };


### PR DESCRIPTION
# 작업 내용 (TODO)

- [x] mutate를 사용하여 캐시 제어, 깜빡임 현상 수정
- [x] SWR의 전역 옵션 리팩토링

참조: https://github.com/prgrms-web-devcourse/Team-BackFro-ArtZip-FE/pull/283

## 깜빡임 현상 수정
후기 데이터 업데이트 시, SWR의 캐시로 인한 깜빡임 현상 수정 
SWR의 mutate를 사용하여 캐시를 제어했습니다. 

https://user-images.githubusercontent.com/80658269/192989639-d352c179-c884-4421-9a64-142ee5ea0593.mp4

후기 수정 시에도 깜빡임 현상이 있었는데 이를 수정했습니다. 

https://user-images.githubusercontent.com/80658269/192989669-cb903ded-f8e1-433c-967a-a3cc8c1b062f.mp4

## SWR의 전역 옵션 리팩토링
axios 인스턴스인 `authRequest`, `unAuthRequest`를 사용하는 방식입니다.
`baseUrl` 및 `토큰 재발급` 로직을 재사용할 수 있다는 장점이 있습니다.  

https://github.com/prgrms-web-devcourse/Team-BackFro-ArtZip-FE/commit/c94ef96e8d44105bad4c30d7847bcce121800f90

# 논의하고 싶은 부분
mutate를 적용하였으나, 
지금보다 좀 더 효율적인 방식이 있다는 생각이 드네요. 
함께 고민해봐도 좋을 것 같습니다. 

close #297
