### PR TITLE
refactor: 전시회 상세 페이지 SSR 적용

### DIFF
--- a/components/organisms/ExhibitionDetail/index.tsx
+++ b/components/organisms/ExhibitionDetail/index.tsx
@@ -9,6 +9,7 @@ import { useRecoilValue } from 'recoil';
 import { userAtom } from 'states';
 import { ExhibitionSingleData } from 'types/apis/exhibition';
 import { EXHIBITION_GENRE, EXHIBITION_PLACE } from '../../../constants';
+import Image from 'next/image';
 
 interface ExhibitionDetailProps {
   exhibitionDetail: ExhibitionSingleData;
@@ -66,7 +67,10 @@ const ExhibitionDetail = ({ exhibitionDetail }: ExhibitionDetailProps) => {
   };
   return (
     <S.ExhibitionContainer>
-      <S.Thumbnail src={thumbnail} preview={false}></S.Thumbnail>
+      <S.ThumbnailWrapper>
+        <Image src={thumbnail} layout="fill" alt="Exhibition Thumbnail" />
+      </S.ThumbnailWrapper>
+
       <S.Container>
         <S.InfoContainer>
           <Tooltip title={name}>

--- a/components/organisms/ExhibitionDetail/style.ts
+++ b/components/organisms/ExhibitionDetail/style.ts
@@ -15,8 +15,9 @@ export const ExhibitionContainer = styled.div`
     align-items: center;
   }
 `;
-export const Thumbnail = styled(Image)`
-  margin-top: 10px;
+
+export const ThumbnailWrapper = styled.div`
+  position: relative;
   width: 280px;
   height: 400px;
   box-shadow: 0 14px 28px rgba(0, 0, 0, 0.05), 0 10px 10px rgba(0, 0, 0, 0.05);

--- a/pages/exhibitions/detail/[id]/index.tsx
+++ b/pages/exhibitions/detail/[id]/index.tsx
@@ -11,11 +11,10 @@ import Map from 'components/atoms/Map';
 import { useEffect, useState } from 'react';
 import { message } from 'antd';
 import { authorizeFetch } from 'utils';
+import axios from 'axios';
 
 const ExhibitionDetailPage = (data: ExhibitionDetailResponse) => {
-  const router = useRouter();
-  const { id } = router.query;
-  const [exhibitionData, setExhibitionData] = useState(data.data);
+  const exhibitionData = data.data;
 
   return (
     <>
@@ -126,9 +125,8 @@ export const getServerSideProps = async (context: GetServerSidePropsContext) => 
       },
     };
   }
-
   const { data } = await exhibitionAPI.getDetail(Number(id));
-  return { props: { data: data } };
+  return { props: { data: data.data } };
 };
 
 export default ExhibitionDetailPage;


### PR DESCRIPTION
# 작업 내용 (TODO)

- [x] 전시회 상세 페이지 SSR 적용
- [x] thumbnail next/image로 변경

@dar-jeeling 
올려주신 디스커션( #313 )에서는 axios 객체 만들어서 사용하라고 되어있었는데, 단님 PR보니까 기존 api사용 하신거 같아서 저도 그렇게 했습니다 !!

CSR 없이도 동작 잘 해서 다은님 조언대로 SSR만 사용하였어요 !
덕분에 작업하기 수월했습니당 감사해요 !!


close #304
