### PR TITLE
refactor: ReviewEditForm 코드 개선

### DIFF
--- a/components/organisms/ReviewEditForm/fields/ExhibitionSearchBar/index.tsx
+++ b/components/organisms/ReviewEditForm/fields/ExhibitionSearchBar/index.tsx
@@ -23,7 +23,6 @@ interface ExhibitionSearchBarProps {
     name: string;
     thumbnail: string;
   };
-  isPrevDataChanged?: boolean;
   wasSubmitted: boolean;
 }
 
@@ -34,10 +33,7 @@ interface SearchResult {
 }
 
 const ExhibitionSearchBar = forwardRef(
-  (
-    { type, prevData, isPrevDataChanged, wasSubmitted }: ExhibitionSearchBarProps,
-    ref: ForwardedRef<FieldGetter>,
-  ) => {
+  ({ type, prevData, wasSubmitted }: ExhibitionSearchBarProps, ref: ForwardedRef<FieldGetter>) => {
     const [exhibitionId, setExhibitionId] = useState(prevData ? prevData.id : 0);
     const [searchWord, setSearchWord] = useState('');
     const [exhibitionName, setExhibitionName] = useState(prevData ? prevData.name : '');
@@ -50,13 +46,13 @@ const ExhibitionSearchBar = forwardRef(
     const displayErrorMessage = wasSubmitted && !!error;
 
     useEffect(() => {
-      if (isPrevDataChanged && prevData) {
+      if (prevData) {
         setExhibitionId(prevData.id);
         setExhibitionName(prevData.name);
         setExhibitionThumbnail(prevData.thumbnail);
         setError(MESSAGE.NO_ERROR);
       }
-    }, [isPrevDataChanged]);
+    }, [prevData]);
 
     const handleSearch = useCallback(async () => {
       const isEmpty = !/\S/.test(searchWord);

--- a/components/organisms/ReviewEditForm/fields/ExhibitionSearchBar/index.tsx
+++ b/components/organisms/ReviewEditForm/fields/ExhibitionSearchBar/index.tsx
@@ -94,7 +94,7 @@ const ExhibitionSearchBar = forwardRef(
           exhibitionThumbnail,
         }),
         getFieldError: () => ({
-          exhibition: error,
+          exhibitionId: error,
         }),
       }),
       [exhibitionId, error],

--- a/components/organisms/ReviewEditForm/index.tsx
+++ b/components/organisms/ReviewEditForm/index.tsx
@@ -3,7 +3,7 @@ import { Button, Form, message, UploadFile } from 'antd';
 import { reviewAPI } from 'apis';
 import { useStoredReview, useDebounce } from 'hooks';
 import { useRouter } from 'next/router';
-import { useRef, useState, useEffect, RefObject, createRef } from 'react';
+import { useRef, useState, useEffect, RefObject, createRef, useMemo } from 'react';
 import { PhotoProps } from 'types/model';
 import { convertFilesToFormData, convertObjectToFormData, getErrorMessage } from 'utils';
 import {
@@ -52,10 +52,9 @@ interface ReviewEditFormProps {
     isPublic: boolean;
     photos?: PhotoProps[];
   };
-  isPrevDataChanged?: boolean;
 }
 
-const ReviewEditForm = ({ type, prevData, isPrevDataChanged }: ReviewEditFormProps) => {
+const ReviewEditForm = ({ type, prevData }: ReviewEditFormProps) => {
   const fields = useRef<RefObject<FieldGetter>[]>(
     Array.from({ length: FIELD_LENGTH }, () => createRef<FieldGetter>()),
   );
@@ -150,21 +149,22 @@ const ReviewEditForm = ({ type, prevData, isPrevDataChanged }: ReviewEditFormPro
     };
   }, []);
 
+  const prevExhibitionData = useMemo(() => {
+    if (prevData) {
+      return {
+        id: prevData.exhibitionId,
+        name: prevData.exhibitionName,
+        thumbnail: prevData.exhibitionThumbnail,
+      };
+    }
+  }, [prevData]);
+
   return (
     <EditForm layout="vertical">
       <FormItem label={LABEL.EXHIBITION} htmlFor={LABEL.EXHIBITION}>
         <ExhibitionSearchBar
           type={type}
-          prevData={
-            prevData
-              ? {
-                  id: prevData.exhibitionId,
-                  name: prevData.exhibitionName,
-                  thumbnail: prevData.exhibitionThumbnail,
-                }
-              : undefined
-          }
-          isPrevDataChanged={isPrevDataChanged}
+          prevData={prevExhibitionData}
           wasSubmitted={wasSubmitted}
           ref={fields.current[0]}
         />

--- a/components/organisms/ReviewEditForm/index.tsx
+++ b/components/organisms/ReviewEditForm/index.tsx
@@ -19,15 +19,24 @@ import { SUBMIT_MESSAGE, LABEL } from './utils/constants';
 const FIELD_LENGTH = 6;
 const MAX_IMAGE_NUMBER = 9;
 
+export type FieldName =
+  | 'exhibitionId'
+  | 'exhibitionName'
+  | 'exhibitionThumbnail'
+  | 'date'
+  | 'title'
+  | 'content'
+  | 'isPublic'
+  | 'deletedPhotos';
 export type FieldValue = string | number | boolean | number[];
 export type FieldError = string;
 
 export interface FieldGetter {
   getFieldValue: () => {
-    [key: string]: FieldValue;
+    [k in FieldName]?: FieldValue;
   };
   getFieldError: () => {
-    [key: string]: FieldError;
+    [k in FieldName]?: FieldError;
   };
 }
 

--- a/pages/reviews/create/index.tsx
+++ b/pages/reviews/create/index.tsx
@@ -12,7 +12,6 @@ const ReviewCreatePage = () => {
   const { query } = useRouter();
   const [prevData, setPrevData] = useState(query);
   const [isModalOn, setIsModalOn] = useState(false);
-  const [isPrevDataChanged, setIsPrevDataChanged] = useState(false);
   const { getStoredReview, removeStoredReview } = useStoredReview();
   const storedReview = getStoredReview();
 
@@ -26,7 +25,6 @@ const ReviewCreatePage = () => {
 
   const handleModalOk = () => {
     setPrevData(storedReview);
-    setIsPrevDataChanged(true);
     setIsModalOn(false);
   };
 
@@ -65,7 +63,6 @@ const ReviewCreatePage = () => {
                   }
                 : undefined
             }
-            isPrevDataChanged={isPrevDataChanged}
           />
         </Section>
         <Modal


### PR DESCRIPTION
# 작업 내용 (TODO)

`ReviewEditForm` 컴포넌트의 코드를 일부 개선했습니다.

- Index signature를 Mapped type으로 수정
- 불필요한 props 삭제

`isPrevDataChanged`라는 props를 삭제하고 useMemo를 사용했습니다. 

close #340 
