### PR TITLE
refactor: 무한 스크롤 로직 변경

### DIFF
--- a/hooks/useInfiniteScroll/index.ts
+++ b/hooks/useInfiniteScroll/index.ts
@@ -1,37 +1,67 @@
-import { useState, useEffect } from 'react';
-import { throttleOnRendering } from 'utils';
+// ref : https://velog.io/@rkd028/React-Infinite-Scroll-%EA%B5%AC%ED%98%84-IntersectionObserver
 
-const useInfiniteScroll = (fetchCallback: () => void) => {
-  const [fetching, setFetching] = useState(false);
+import { useEffect, useState, useMemo, MutableRefObject } from 'react';
 
-  const handleScrollThrottle = throttleOnRendering(() => {
-    const scrollHeight = document.documentElement.scrollHeight;
-    const scrollTop = document.documentElement.scrollTop;
-    const clientHeight = document.documentElement.clientHeight;
+interface InfiniteScrollProps {
+  root?: Element | null;
+  rootMargin?: string;
+  target: MutableRefObject<HTMLDivElement | null>;
+  threshold?: number;
+  targetArray: Array<unknown>;
+  pageSize: number;
+  endPoint?: number;
+}
 
-    const isEndOfScroll = scrollTop + clientHeight >= scrollHeight;
-    if (isEndOfScroll && !fetching) {
-      setFetching(true);
-    }
-  });
+const useInfiniteScroll = ({
+  root = null,
+  target,
+  threshold = 1,
+  rootMargin = '0px',
+  targetArray,
+  pageSize,
+  endPoint = 1,
+}: InfiniteScrollProps) => {
+  const [count, setCount] = useState<number>(0);
+
+  const observer = useMemo(() => {
+    return new IntersectionObserver(
+      (entries, observer) => {
+        if (target?.current === null) {
+          return;
+        }
+        if (entries[0].isIntersecting) {
+          setCount((v) => v + 1);
+          observer.disconnect();
+        }
+      },
+      {
+        root,
+        rootMargin,
+        threshold,
+      },
+    );
+  }, [target, root, rootMargin, threshold]);
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScrollThrottle);
-    return () => {
-      window.removeEventListener('scroll', handleScrollThrottle);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (!fetching) {
+    if (target?.current === null) {
       return;
-    } else {
-      fetchCallback();
-      setFetching(false);
     }
-  }, [fetching]);
 
-  return [fetching, setFetching];
+    if (pageSize * (count + 1) <= targetArray.length) {
+      observer.observe(target.current.children[target.current.children.length - endPoint]);
+    }
+
+    return () => {
+      if (target.current !== null && observer) {
+        observer.unobserve(target.current);
+      }
+    };
+  }, [count, targetArray, target, pageSize]);
+
+  return {
+    count,
+    setCount,
+  };
 };
 
 export default useInfiniteScroll;

--- a/hooks/useInfiniteScroll/index.ts
+++ b/hooks/useInfiniteScroll/index.ts
@@ -24,22 +24,24 @@ const useInfiniteScroll = ({
   const [count, setCount] = useState<number>(0);
 
   const observer = useMemo(() => {
-    return new IntersectionObserver(
-      (entries, observer) => {
-        if (target?.current === null) {
-          return;
-        }
-        if (entries[0].isIntersecting) {
-          setCount((v) => v + 1);
-          observer.disconnect();
-        }
-      },
-      {
-        root,
-        rootMargin,
-        threshold,
-      },
-    );
+    if (typeof window !== 'undefined') {
+      return new IntersectionObserver(
+        (entries, observer) => {
+          if (target?.current === null) {
+            return;
+          }
+          if (entries[0].isIntersecting) {
+            setCount((v) => v + 1);
+            observer.disconnect();
+          }
+        },
+        {
+          root,
+          rootMargin,
+          threshold,
+        },
+      );
+    }
   }, [target, root, rootMargin, threshold]);
 
   useEffect(() => {
@@ -48,7 +50,8 @@ const useInfiniteScroll = ({
     }
 
     if (pageSize * (count + 1) <= targetArray.length) {
-      observer.observe(target.current.children[target.current.children.length - endPoint]);
+      observer &&
+        observer.observe(target.current.children[target.current.children.length - endPoint]);
     }
 
     return () => {

--- a/pages/community/index.tsx
+++ b/pages/community/index.tsx
@@ -40,7 +40,7 @@ const CommunityPage = ({ data }: ReviewMultiReadResponse) => {
   const { userId } = useRecoilValue(userAtom);
 
   const target = useRef(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const { count } = useInfiniteScroll({
     target: target,

--- a/pages/reviews/detail/[id]/index.tsx
+++ b/pages/reviews/detail/[id]/index.tsx
@@ -3,7 +3,7 @@ import { ReviewDetail, CommentWrite, CommentList } from 'components/organisms';
 import { ReviewSingleReadData, ReviewSingleReadResponse } from 'types/apis/review';
 import { reviewAPI } from 'apis';
 import { message, Modal } from 'antd';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useInfiniteScroll } from 'hooks';
 import { CommentProps } from 'types/model';
@@ -11,18 +11,15 @@ import styled from '@emotion/styled';
 import useSWR from 'swr';
 import { GetServerSidePropsContext } from 'next';
 import { authorizeFetch } from 'utils';
+import { Spinner } from 'components/atoms';
 
 const ReviewDetailPage = (reviewSingleRes: { reviewSingleRes: ReviewSingleReadData }) => {
   const router = useRouter();
   const { id } = router.query;
   const { data: reviewCommentData } = useSWR(`api/v1/reviews/${id}/comments`);
   const { reviewSingleRes: reviewSingleData } = reviewSingleRes;
-
-  const { reviewId, content, commentCount, comments } = reviewSingleData;
-
+  const { reviewId, commentCount, comments } = reviewSingleData;
   const { totalPage, pageNumber } = comments;
-
-  const validComments = comments.content.map((comment) => comment.isDeleted === false);
 
   useEffect(() => {
     if (reviewCommentData) {
@@ -47,7 +44,26 @@ const ReviewDetailPage = (reviewSingleRes: { reviewSingleRes: ReviewSingleReadDa
     setCurrentPage(currentPage + 1);
   };
 
-  const [fetching, setFetching] = useInfiniteScroll(getMoreComment);
+  const target = useRef(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const { count } = useInfiniteScroll({
+    target: target,
+    targetArray: reviewComments,
+    threshold: 0.2,
+    pageSize: 10,
+    endPoint: 5,
+  });
+
+  useEffect(() => {
+    if (count === 0) {
+      return;
+    }
+    setIsLoading(true);
+    setTimeout(() => {
+      getMoreComment();
+      setIsLoading(false);
+    }, 1000);
+  }, [count]);
 
   // 댓글 액션
   const showModal = () => {
@@ -85,7 +101,7 @@ const ReviewDetailPage = (reviewSingleRes: { reviewSingleRes: ReviewSingleReadDa
           onDeleteButtonClick={showModal}
           commentCount={reviewCommentCount}
         />
-        <CommentContainer>
+        <CommentContainer ref={target}>
           <CommentWrite reviewId={reviewId} onCommentReload={handleCommentReload} />
           {reviewComments && (
             <CommentList
@@ -97,6 +113,7 @@ const ReviewDetailPage = (reviewSingleRes: { reviewSingleRes: ReviewSingleReadDa
             />
           )}
         </CommentContainer>
+        {isLoading && <Spinner />}
       </>
 
       <Modal

--- a/pages/reviews/detail/[id]/index.tsx
+++ b/pages/reviews/detail/[id]/index.tsx
@@ -45,7 +45,7 @@ const ReviewDetailPage = (reviewSingleRes: { reviewSingleRes: ReviewSingleReadDa
   };
 
   const target = useRef(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const { count } = useInfiniteScroll({
     target: target,
     targetArray: reviewComments,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -146,3 +146,7 @@ a:hover {
 .hide {
   visibility: hidden;
 }
+
+.ant-spin-dot-item {
+  background-color: #646fd4;
+}

--- a/types/apis/review/index.ts
+++ b/types/apis/review/index.ts
@@ -46,7 +46,7 @@ export interface ReviewMultiReadData {
   pageNumber: number; //페이지 넘버
   pageSize: number; //페이지 사이즈
   totalElements: number; // 전체 요소 수
-  totalPages: number; //전체 페이지 수
+  totalPage: number; //전체 페이지 수
 }
 
 export interface ReviewMultiReadResponse extends BaseResponse {


### PR DESCRIPTION
# 작업 내용 (TODO)
- [x] 커뮤니티 페이지 첫 데이터 패치를 SSR 로 변경
- [x] 기존 scroll 이벤트를 사용하던 무한 스크롤 로직 Intersection observer 로 변경
- [x] 무한 스크롤 데이터 받아오기 시 spinner 추가
- [x] spinner 색상 테마 색깔에 맞게 변경

# 사진 (구현 캡쳐)
- 피드 무한 스크롤 (커뮤니티 페이지)
![피드 무한 스크롤](https://user-images.githubusercontent.com/74234333/201040962-1a00e87a-29b5-4e8f-b367-93c5064859af.gif)

- 댓글 무한 스크롤 (리뷰 디테일 페이지)
![댓글 무한 스크롤](https://user-images.githubusercontent.com/74234333/201040571-c1ddbcdb-03be-48bb-9c05-935aefd5e11a.gif)


# 논의하고 싶은 부분

spinner 색상 로딩 컴포넌트와 맞추기 위하여 제가 변경하였습니다!

close #327 
